### PR TITLE
Added optional region and variant params to TTS intent

### DIFF
--- a/app/src/main/java/com/termux/api/TextToSpeechAPI.java
+++ b/app/src/main/java/com/termux/api/TextToSpeechAPI.java
@@ -47,6 +47,8 @@ public class TextToSpeechAPI {
         @Override
         protected void onHandleIntent(final Intent intent) {
             final String speechLanguage = intent.getStringExtra("language");
+            final String speechRegion = intent.getStringExtra("region");
+            final String speechVariant = intent.getStringExtra("variant");
             final String speechEngine = intent.getStringExtra("engine");
             final float speechPitch = intent.getFloatExtra("pitch", 1.0f);
 
@@ -148,7 +150,7 @@ public class TextToSpeechAPI {
                         });
 
                         if (speechLanguage != null) {
-                            int setLanguageResult = mTts.setLanguage(new Locale(speechLanguage));
+                            int setLanguageResult = mTts.setLanguage(getLocale(speechLanguage, speechRegion, speechVariant));
                             if (setLanguageResult != TextToSpeech.LANG_AVAILABLE) {
                                 TermuxApiLogger.error("tts.setLanguage('" + speechLanguage + "') returned " + setLanguageResult);
                             }
@@ -187,4 +189,17 @@ public class TextToSpeechAPI {
         }
     }
 
+    private static Locale getLocale(String language, String region, String variant) {
+        Locale result = null;
+        if (region != null) {
+            if (variant != null) {
+                result = new Locale(language, region, variant);
+            } else {
+                result = new Locale(language, region);
+            }
+        } else {
+            result = new Locale(language);
+        }
+        return result;
+    }
 }


### PR DESCRIPTION
Currently I can only specify the language in termux-tts-speak. Appending the region (e.g. en_GB) doesn't work because new Locale(String language) constructor is used.
So actually one can only use american female voice and no other male or female english voices at the same time.
See http://stackoverflow.com/questions/36681232/android-tts-male-voices for more information.
This patch adds 2 optional parameters to intent for region and variant.