### PR TITLE
Fix link to termux-api-package

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The two sockets are used to forward stdin from `termux-api` to the relevant API 
 
 Client scripts
 ==============
-Client scripts which processes command line arguments before calling the `termux-api` helper binary are available in [the termux-api package](https://github.com/termux/termux-packages/tree/master/packages/termux-api).
+Client scripts which processes command line arguments before calling the `termux-api` helper binary are available in [the termux-api package](https://github.com/termux/termux-api-package).
 
 Ideas
 =====


### PR DESCRIPTION
Links to [termux/termux-api-package](https://github.com/termux/termux-api-package), instead of `termux-api` in [termux/termux-packages](https://github.com/termux/termux-packages/tree/master/packages/termux-api), as the current one doesn't contain the mentioned client scripts.