### PR TITLE
gets info for fast_mixer

### DIFF
--- a/app/src/main/java/com/termux/api/AudioAPI.java
+++ b/app/src/main/java/com/termux/api/AudioAPI.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.media.AudioManager;
 import android.util.JsonWriter;
+import android.media.AudioTrack; 
 
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.ResultReturner.ResultWriter;
@@ -18,13 +19,17 @@ public class AudioAPI {
 	    String SampleRate = am.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE);
 	    String framesPerBuffer = am.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER);
 	    String AudioUnprocessed = am.getProperty(AudioManager.PROPERTY_SUPPORT_AUDIO_SOURCE_UNPROCESSED);
+	    int nativeoutput = AudioTrack.getNativeOutputSampleRate(AudioManager.STREAM_MUSIC); 
 	    int volume_level= am.getStreamVolume(AudioManager.STREAM_MUSIC);
+	    int maxvolume_level = am.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
 	    public void writeJson(JsonWriter out) throws Exception {
 		out.beginObject(); 
 		out.name("PROPERTY_OUTPUT_SAMPLE_RATE").value(SampleRate);
 		out.name("PROPERTY_OUTPUT_FRAMES_PER_BUFFER").value(framesPerBuffer);
 		out.name("PROPERTY_SUPPORT_AUDIO_SOURCE_UNPROCESSED").value(AudioUnprocessed);
-		out.name("STREAM_MUSIC").value(volume_level);
+		out.name("STREAM_MUSIC_VOLUME").value(volume_level);
+		out.name("STREAM_MUSIC_MAXVOLUME").value(maxvolume_level);
+		out.name("CURRENT_NATIVE_OUTPUT_SAMPLERATE").value(nativeoutput);
 		out.endObject();
 		}
 	});

--- a/app/src/main/java/com/termux/api/AudioAPI.java
+++ b/app/src/main/java/com/termux/api/AudioAPI.java
@@ -1,0 +1,29 @@
+package com.termux.api;
+
+import android.content.Context;
+import android.content.Intent;
+import android.media.AudioManager;
+import android.util.JsonWriter;
+
+import com.termux.api.util.ResultReturner;
+import com.termux.api.util.ResultReturner.ResultWriter;
+
+
+
+public class AudioAPI {
+    static void onReceive(TermuxApiReceiver apiReceiver, final Context context, Intent intent) {
+	ResultReturner.returnData(apiReceiver, intent, new ResultReturner.ResultJsonWriter() {
+	    
+	    AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+	    String SampleRate = am.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE);
+	    String framesPerBuffer = am.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER);
+	    public void writeJson(JsonWriter out) throws Exception {
+		out.beginObject(); 
+		out.name("PROPERTY_OUTPUT_SAMPLE_RATE").value(SampleRate);
+		out.name("PROPERTY_OUTPUT_FRAMES_PER_BUFFER").value(framesPerBuffer);
+		out.endObject();
+		}
+	});
+    }
+}
+

--- a/app/src/main/java/com/termux/api/AudioAPI.java
+++ b/app/src/main/java/com/termux/api/AudioAPI.java
@@ -17,10 +17,14 @@ public class AudioAPI {
 	    AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
 	    String SampleRate = am.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE);
 	    String framesPerBuffer = am.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER);
+	    String AudioUnprocessed = am.getProperty(AudioManager.PROPERTY_SUPPORT_AUDIO_SOURCE_UNPROCESSED);
+	    int volume_level= am.getStreamVolume(AudioManager.STREAM_MUSIC);
 	    public void writeJson(JsonWriter out) throws Exception {
 		out.beginObject(); 
 		out.name("PROPERTY_OUTPUT_SAMPLE_RATE").value(SampleRate);
 		out.name("PROPERTY_OUTPUT_FRAMES_PER_BUFFER").value(framesPerBuffer);
+		out.name("PROPERTY_SUPPORT_AUDIO_SOURCE_UNPROCESSED").value(AudioUnprocessed);
+		out.name("STREAM_MUSIC").value(volume_level);
 		out.endObject();
 		}
 	});

--- a/app/src/main/java/com/termux/api/TermuxApiReceiver.java
+++ b/app/src/main/java/com/termux/api/TermuxApiReceiver.java
@@ -19,7 +19,10 @@ public class TermuxApiReceiver extends BroadcastReceiver {
         }
 
         switch (apiMethod) {
-            case "BatteryStatus":
+	    case "AudioInfo":
+	        AudioAPI.onReceive(this, context, intent);
+		break;
+	    case "BatteryStatus":
                 BatteryStatusAPI.onReceive(this, context, intent);
                 break;
             case "CameraInfo":


### PR DESCRIPTION
This allows pulseadio and probably other sound apps to use the defined sample rate to get fast mixer working. Which is lower latency and other benefits.   