### PR TITLE
MediaPlayerApi playHandler: don't always print failure

### DIFF
--- a/app/src/main/java/com/termux/api/MediaPlayerAPI.java
+++ b/app/src/main/java/com/termux/api/MediaPlayerAPI.java
@@ -204,7 +204,7 @@ public class MediaPlayerAPI {
                 }
                 try {
                     player.setDataSource(context, Uri.fromFile(mediaFile));
-                    player.prepareAsync();
+                    player.prepare();
                     if (player.isPlaying()) {
                         result.message = "Now Playing: " + mediaFile.getName();
                     } else {


### PR DESCRIPTION
the `player.isPlaying()` call was completing before the `player.prepareAsync()` call, returning `"Failed to play: "` despite playing the file, so i changed it to just `player.prepare()`