### PR TITLE
Fix scenarios causing termux-dialog to hang

### DIFF
--- a/app/src/main/java/com/termux/api/DialogActivity.java
+++ b/app/src/main/java/com/termux/api/DialogActivity.java
@@ -54,7 +54,7 @@ import java.util.Objects;
  */
 public class DialogActivity extends AppCompatActivity {
 
-    static boolean resultReturned = false;
+    private boolean resultReturned = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -79,15 +79,6 @@ public class DialogActivity extends AppCompatActivity {
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         setIntent(intent);
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-
-        if (!resultReturned) {
-            postResult(this, null);
-        }
     }
 
     @Override

--- a/app/src/main/java/com/termux/api/TermuxApiReceiver.java
+++ b/app/src/main/java/com/termux/api/TermuxApiReceiver.java
@@ -64,7 +64,7 @@ public class TermuxApiReceiver extends BroadcastReceiver {
                 }
                 break;
             case "Dialog":
-                context.startActivity(new Intent(context, DialogActivity.class).putExtras(intent.getExtras()).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
+                context.startActivity(new Intent(context, DialogActivity.class).putExtras(intent.getExtras()).addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK));
                 break;
             case "Download":
                 DownloadAPI.onReceive(this, context, intent);


### PR DESCRIPTION
If termux-dialog is called while Termux already has a dialog open, the new dialog fails to open and the command will hang until it is manually terminated. This fix allows multiple dialogs to be open at once and ensures that termux-dialog will not hang.

This also fixes #193.