### PR TITLE
Notification Improvements

### DIFF
--- a/app/src/main/java/com/termux/api/NotificationAPI.java
+++ b/app/src/main/java/com/termux/api/NotificationAPI.java
@@ -10,6 +10,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.provider.Settings;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.TermuxApiLogger;
@@ -72,6 +73,8 @@ public class NotificationAPI {
 
         long[] vibratePattern = intent.getLongArrayExtra("vibrate");
         boolean useSound = intent.getBooleanExtra("sound", false);
+        boolean ongoing = intent.getBooleanExtra("ongoing", false);
+        boolean alertOnce = intent.getBooleanExtra("alert-once", true);
 
         String actionExtra = intent.getStringExtra("action");
 
@@ -79,12 +82,18 @@ public class NotificationAPI {
         if (id == null) id = UUID.randomUUID().toString();
         final String notificationId = id;
 
+        String groupKey = intent.getStringExtra("group");
+
         final Notification.Builder notification = new Notification.Builder(context);
         notification.setSmallIcon(R.drawable.ic_event_note_black_24dp);
         notification.setColor(0xFF000000);
         notification.setContentTitle(title);
         notification.setPriority(priority);
+        notification.setOngoing(ongoing);
+        notification.setOnlyAlertOnce(alertOnce);
         notification.setWhen(System.currentTimeMillis());
+
+        if (groupKey != null) notification.setGroup(groupKey);
 
         if (ledColor != 0) {
             notification.setLights(ledColor, ledOnMs, ledOffMs);

--- a/app/src/main/java/com/termux/api/NotificationAPI.java
+++ b/app/src/main/java/com/termux/api/NotificationAPI.java
@@ -19,6 +19,7 @@ import com.termux.api.util.TermuxApiLogger;
 import java.io.File;
 import java.io.PrintWriter;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.UUID;
 
 public class NotificationAPI {
@@ -111,7 +112,7 @@ public class NotificationAPI {
         }
 
         String styleType = intent.getStringExtra("type");
-        if(styleType.equals("media")) {
+        if(Objects.equals(styleType, "media")) {
             String mediaPrevious = intent.getStringExtra("media-previous");
             String mediaPause = intent.getStringExtra("media-pause");
             String mediaPlay = intent.getStringExtra("media-play");


### PR DESCRIPTION
* Added `ongoing` bool extra to implement https://github.com/termux/termux-api/issues/62 
* Added the `alert-once` bool extra to avoid having alerts when editing a notification.
* Added `group` extra to allow grouping select notifications.

* Added `image-path` which requires an absolute path to the image, This half implements https://github.com/termux/termux-api/issues/60, to actually display on the lockscreen we need to create a media-session and I haven't figured out the best way to handle this yet. 
* Added media style layout specifiable using `type` extra of value `"media"`, this requires the extras `media-previous`, `media-pause`, `media-play` and `media-next` to be specified with actions. 
* To make adding additional actions easier the pendingIntent code was turned in to a function to remove a lot of duplicate code,