### PR TITLE
Change app to use sockets with json instead of Intents [WIP]

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,7 +3,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="disableWrapperSourceDistributionNotification" value="true" />
+        <compositeConfiguration>
+          <compositeBuild compositeDefinitionSource="SCRIPT" />
+        </compositeConfiguration>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,7 +43,6 @@
     <permission android:name="com.termux.sharedfiles.READ" android:protectionLevel="signature" />
 
     <application
-        android:largeHeap="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,7 @@
     <permission android:name="com.termux.sharedfiles.READ" android:protectionLevel="signature" />
 
     <application
+        android:largeHeap="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
@@ -50,6 +51,7 @@
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.Light"
         tools:ignore="GoogleAppIndexingWarning">
+        <service android:name="com.termux.api.TermuxApiService"/>
         <receiver android:name="com.termux.api.TermuxApiReceiver"/>
         <activity android:name="com.termux.api.DialogActivity" android:theme="@style/DialogTheme" android:noHistory="true" android:excludeFromRecents="true" android:exported="false"/>
         <activity android:name=".FingerprintAPI$FingerprintActivity" android:theme="@android:style/Theme.NoDisplay"

--- a/app/src/main/java/com/termux/api/AudioAPI.java
+++ b/app/src/main/java/com/termux/api/AudioAPI.java
@@ -12,7 +12,7 @@ import com.termux.api.util.ResultReturner;
 
 public class AudioAPI {
 
-    static void onReceive(TermuxApiReceiver apiReceiver, final Context context, Intent intent) {
+    static void onReceive(final Context context) {
         AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         final String SampleRate = am.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE);
         final String framesPerBuffer = am.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER);
@@ -65,7 +65,7 @@ public class AudioAPI {
             nosr = AudioTrack.getNativeOutputSampleRate(AudioManager.STREAM_MUSIC);
         }
 
-        ResultReturner.returnData(apiReceiver, intent, new ResultReturner.ResultJsonWriter() {
+        ResultReturner.returnData(context, new ResultReturner.ResultJsonWriter() {
             public void writeJson(JsonWriter out) throws Exception {
                 out.beginObject();
                 out.name("PROPERTY_OUTPUT_SAMPLE_RATE").value(SampleRate);

--- a/app/src/main/java/com/termux/api/BatteryStatusAPI.java
+++ b/app/src/main/java/com/termux/api/BatteryStatusAPI.java
@@ -12,8 +12,8 @@ import com.termux.api.util.TermuxApiLogger;
 
 public class BatteryStatusAPI {
 
-    public static void onReceive(TermuxApiReceiver apiReceiver, final Context context, Intent intent) {
-        ResultReturner.returnData(apiReceiver, intent, new ResultJsonWriter() {
+    public static void onReceive(final Context context) {
+        ResultReturner.returnData(context, new ResultJsonWriter() {
             @Override
             public void writeJson(JsonWriter out) throws Exception {
                 Intent batteryStatus = context.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));

--- a/app/src/main/java/com/termux/api/BrightnessAPI.java
+++ b/app/src/main/java/com/termux/api/BrightnessAPI.java
@@ -7,12 +7,14 @@ import android.provider.Settings;
 
 import com.termux.api.util.ResultReturner;
 
+import org.json.JSONObject;
+
 public class BrightnessAPI {
 
-    public static void onReceive(final TermuxApiReceiver receiver, final Context context, final Intent intent) {
+    public static void onReceive(final Context context, JSONObject opts) {
         final ContentResolver contentResolver = context.getContentResolver();
 
-        int brightness = intent.getIntExtra("brightness", 0);
+        int brightness = opts.optInt("brightness", 0);
 
         if (brightness <= 0) {
             brightness = 0;
@@ -21,6 +23,6 @@ public class BrightnessAPI {
         }
 
         Settings.System.putInt(contentResolver, Settings.System.SCREEN_BRIGHTNESS, brightness);
-        ResultReturner.noteDone(receiver, intent);
+        ResultReturner.noteDone(context);
     }
 }

--- a/app/src/main/java/com/termux/api/CallLogAPI.java
+++ b/app/src/main/java/com/termux/api/CallLogAPI.java
@@ -9,6 +9,8 @@ import android.util.JsonWriter;
 
 import com.termux.api.util.ResultReturner;
 
+import org.json.JSONObject;
+
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -20,11 +22,11 @@ import java.util.Locale;
  */
 public class CallLogAPI {
 
-    static void onReceive(final Context context, final Intent intent) {
-        final int offset = intent.getIntExtra("offset", 0);
-        final int limit = intent.getIntExtra("limit", 50);
+    static void onReceive(final Context context, final JSONObject opts) {
+        final int offset = opts.optInt("offset");
+        final int limit = opts.optInt("limit", 50);
 
-        ResultReturner.returnData(context, intent, new ResultReturner.ResultJsonWriter() {
+        ResultReturner.returnData(context, new ResultReturner.ResultJsonWriter() {
             public void writeJson(JsonWriter out) throws Exception {
                 getCallLogs(context, out, offset, limit);
             }

--- a/app/src/main/java/com/termux/api/CameraInfoAPI.java
+++ b/app/src/main/java/com/termux/api/CameraInfoAPI.java
@@ -1,7 +1,6 @@
 package com.termux.api;
 
 import android.content.Context;
-import android.content.Intent;
 import android.graphics.ImageFormat;
 import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraManager;
@@ -16,8 +15,8 @@ import com.termux.api.util.ResultReturner.ResultJsonWriter;
 
 public class CameraInfoAPI {
 
-    static void onReceive(TermuxApiReceiver apiReceiver, final Context context, Intent intent) {
-        ResultReturner.returnData(apiReceiver, intent, new ResultJsonWriter() {
+    static void onReceive(final Context context) {
+        ResultReturner.returnData(context, new ResultJsonWriter() {
             @Override
             public void writeJson(JsonWriter out) throws Exception {
                 final CameraManager manager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);

--- a/app/src/main/java/com/termux/api/ClipboardAPI.java
+++ b/app/src/main/java/com/termux/api/ClipboardAPI.java
@@ -10,19 +10,21 @@ import android.text.TextUtils;
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.ResultReturner.ResultWriter;
 
+import org.json.JSONObject;
+
 import java.io.PrintWriter;
 
 public class ClipboardAPI {
 
-    static void onReceive(TermuxApiReceiver apiReceiver, final Context context, Intent intent) {
+    static void onReceive(final Context context, final JSONObject opts) {
         final ClipboardManager clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
         final ClipData clipData = clipboard.getPrimaryClip();
 
-        boolean version2 = "2".equals(intent.getStringExtra("api_version"));
+        boolean version2 = "2".equals(opts.optString("api_version"));
         if (version2) {
-            boolean set = intent.getBooleanExtra("set", false);
+            boolean set = opts.optBoolean("set", false);
             if (set) {
-                ResultReturner.returnData(apiReceiver, intent, new ResultReturner.WithStringInput() {
+                ResultReturner.returnData(context, new ResultReturner.WithStringInput() {
                     @Override
                     protected boolean trimInput() {
                         return false;
@@ -34,7 +36,7 @@ public class ClipboardAPI {
                     }
                 });
             } else {
-                ResultReturner.returnData(apiReceiver, intent, new ResultWriter() {
+                ResultReturner.returnData(context, new ResultWriter() {
                     @Override
                     public void writeResult(PrintWriter out) {
                         if (clipData == null) {
@@ -53,13 +55,13 @@ public class ClipboardAPI {
                 });
             }
         } else {
-            final String newClipText = intent.getStringExtra("text");
+            final String newClipText = opts.optString("text");
             if (newClipText != null) {
                 // Set clip.
                 clipboard.setPrimaryClip(ClipData.newPlainText("", newClipText));
             }
 
-            ResultReturner.returnData(apiReceiver, intent, new ResultWriter() {
+            ResultReturner.returnData(context, new ResultWriter() {
                 @Override
                 public void writeResult(PrintWriter out) {
                     if (newClipText == null) {

--- a/app/src/main/java/com/termux/api/ContactListAPI.java
+++ b/app/src/main/java/com/termux/api/ContactListAPI.java
@@ -15,8 +15,8 @@ import com.termux.api.util.ResultReturner.ResultJsonWriter;
 
 public class ContactListAPI {
 
-    static void onReceive(TermuxApiReceiver apiReceiver, final Context context, Intent intent) {
-        ResultReturner.returnData(apiReceiver, intent, new ResultJsonWriter() {
+    static void onReceive(final Context context) {
+        ResultReturner.returnData(context, new ResultJsonWriter() {
             @Override
             public void writeJson(JsonWriter out) throws Exception {
                 listContacts(context, out);

--- a/app/src/main/java/com/termux/api/DownloadAPI.java
+++ b/app/src/main/java/com/termux/api/DownloadAPI.java
@@ -9,22 +9,24 @@ import android.net.Uri;
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.ResultReturner.ResultWriter;
 
+import org.json.JSONObject;
+
 import java.io.PrintWriter;
 
 public class DownloadAPI {
 
-    static void onReceive(TermuxApiReceiver apiReceiver, final Context context, final Intent intent) {
-        ResultReturner.returnData(apiReceiver, intent, new ResultWriter() {
+    static void onReceive(final Context context, final JSONObject opts) {
+        ResultReturner.returnData(context, new ResultWriter() {
             @Override
             public void writeResult(PrintWriter out) {
-                final Uri downloadUri = intent.getData();
+                final Uri downloadUri = Uri.parse(opts.optString("url"));
                 if (downloadUri == null) {
                     out.println("No download URI specified");
                     return;
                 }
 
-                String title = intent.getStringExtra("title");
-                String description = intent.getStringExtra("description");
+                String title = opts.optString("title");
+                String description = opts.optString("description");
 
                 DownloadManager manager = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
                 Request req = new Request(downloadUri);

--- a/app/src/main/java/com/termux/api/InfraredAPI.java
+++ b/app/src/main/java/com/termux/api/InfraredAPI.java
@@ -7,13 +7,16 @@ import android.util.JsonWriter;
 
 import com.termux.api.util.ResultReturner;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 /**
  * Exposing {@link ConsumerIrManager}.
  */
 public class InfraredAPI {
 
-    static void onReceiveCarrierFrequency(TermuxApiReceiver apiReceiver, final Context context, final Intent intent) {
-        ResultReturner.returnData(apiReceiver, intent, new ResultReturner.ResultJsonWriter() {
+    static void onReceiveCarrierFrequency(final Context context) {
+        ResultReturner.returnData(context, new ResultReturner.ResultJsonWriter() {
             @Override
             public void writeJson(JsonWriter out) throws Exception {
                 ConsumerIrManager irManager = (ConsumerIrManager) context.getSystemService(Context.CONSUMER_IR_SERVICE);
@@ -40,14 +43,20 @@ public class InfraredAPI {
     }
 
 
-    static void onReceiveTransmit(TermuxApiReceiver apiReceiver, final Context context, final Intent intent) {
-        ResultReturner.returnData(apiReceiver, intent, new ResultReturner.ResultJsonWriter() {
+    static void onReceiveTransmit(final Context context, final JSONObject opts) {
+        ResultReturner.returnData(context, new ResultReturner.ResultJsonWriter() {
             @Override
             public void writeJson(JsonWriter out) throws Exception {
                 ConsumerIrManager irManager = (ConsumerIrManager) context.getSystemService(Context.CONSUMER_IR_SERVICE);
 
-                int carrierFrequency = intent.getIntExtra("frequency", -1);
-                int[] pattern = intent.getIntArrayExtra("pattern");
+                int carrierFrequency = opts.optInt("frequency", -1);
+                JSONArray jsonArray = opts.getJSONArray("pattern");
+
+                int[] pattern = new int[jsonArray.length()];
+
+                for(int i = 0; i < jsonArray.length(); i++){
+                    pattern[i] = jsonArray.optInt(i);
+                }
 
                 String error = null;
                 if (!irManager.hasIrEmitter()) {

--- a/app/src/main/java/com/termux/api/LocationAPI.java
+++ b/app/src/main/java/com/termux/api/LocationAPI.java
@@ -15,6 +15,8 @@ import com.termux.api.util.ResultReturner;
 import com.termux.api.util.ResultReturner.ResultJsonWriter;
 import com.termux.api.util.TermuxApiLogger;
 
+import org.json.JSONObject;
+
 import java.io.IOException;
 
 public class LocationAPI {
@@ -23,13 +25,13 @@ public class LocationAPI {
     private static final String REQUEST_ONCE = "once";
     private static final String REQUEST_UPDATES = "updates";
 
-    static void onReceive(TermuxApiReceiver apiReceiver, final Context context, final Intent intent) {
-        ResultReturner.returnData(apiReceiver, intent, new ResultJsonWriter() {
+    static void onReceive(final Context context, final JSONObject opts) {
+        ResultReturner.returnData(context, new ResultJsonWriter() {
             @Override
             public void writeJson(final JsonWriter out) throws Exception {
                 LocationManager manager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
 
-                String provider = intent.getStringExtra("provider");
+                String provider = opts.optString("provider");
                 if (provider == null)
                     provider = LocationManager.GPS_PROVIDER;
                 if (!(provider.equals(LocationManager.GPS_PROVIDER) || provider.equals(LocationManager.NETWORK_PROVIDER) || provider
@@ -41,7 +43,7 @@ public class LocationAPI {
                     return;
                 }
 
-                String request = intent.getStringExtra("request");
+                String request = opts.optString("request");
                 if (request == null)
                     request = REQUEST_ONCE;
                 switch (request) {

--- a/app/src/main/java/com/termux/api/MediaPlayerAPI.java
+++ b/app/src/main/java/com/termux/api/MediaPlayerAPI.java
@@ -10,6 +10,8 @@ import android.os.PowerManager;
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.TermuxApiLogger;
 
+import org.json.JSONObject;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -23,12 +25,12 @@ public class MediaPlayerAPI {
     /**
      * Starts our PlayerService
      */
-    static void onReceive(final Context context, final Intent intent) {
+    static void onReceive(final Context context, JSONObject opts) {
         // Create intent for starting our player service and make sure
         // we retain all relevant info from this intent
         Intent playerService = new Intent(context, PlayerService.class);
-        playerService.setAction(intent.getAction());
-        playerService.putExtras(intent.getExtras());
+        playerService.setAction(opts.optString("action"));
+        playerService.putExtra("opts", opts.toString());
 
         context.startService(playerService);
     }
@@ -82,7 +84,7 @@ public class MediaPlayerAPI {
         }
 
         /**
-         * What we received from TermuxApiReceiver but now within this service
+         * What we received from TermuxApiService but now within this service
          */
         public int onStartCommand(Intent intent, int flags, int startId) {
             String command = intent.getAction();
@@ -161,7 +163,7 @@ public class MediaPlayerAPI {
         protected static void postMediaCommandResult(final Context context, final Intent intent,
                                                      final MediaCommandResult result) {
 
-            ResultReturner.returnData(context, intent, new ResultReturner.ResultWriter() {
+            ResultReturner.returnData(context, new ResultReturner.ResultWriter() {
                 @Override
                 public void writeResult(PrintWriter out) {
                     out.append(result.message + "\n");

--- a/app/src/main/java/com/termux/api/MediaScannerAPI.java
+++ b/app/src/main/java/com/termux/api/MediaScannerAPI.java
@@ -8,22 +8,27 @@ import android.net.Uri;
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.TermuxApiLogger;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 import java.io.File;
 import java.io.PrintWriter;
 import java.util.Stack;
 
 public class MediaScannerAPI {
 
-    static void onReceive(TermuxApiReceiver apiReceiver, final Context context, Intent intent) {
-        final String[] filePaths = intent.getStringArrayExtra("paths");
-        final Boolean recursive = intent.getBooleanExtra("recursive", false);
+    static void onReceive(final Context context, JSONObject opts) {
+        final JSONArray filePathsJson = opts.optJSONArray("paths");
+        final String[] filePaths = new String[filePathsJson.length()];
+
+        final Boolean recursive = opts.optBoolean("recursive", false);
         final Integer[] totalScanned = {0};
-        final Boolean verbose = intent.getBooleanExtra("verbose", false);
+        final Boolean verbose = opts.optBoolean("verbose", false);
         for (int i = 0; i < filePaths.length; i++) {
             filePaths[i] = filePaths[i].replace("\\,", ",");
         }
 
-        ResultReturner.returnData(apiReceiver, intent, new ResultReturner.ResultWriter() {
+        ResultReturner.returnData(context, new ResultReturner.ResultWriter() {
             @Override
             public void writeResult(PrintWriter out) {
                 scanFiles(out, context, filePaths, totalScanned, verbose);

--- a/app/src/main/java/com/termux/api/MicRecorderAPI.java
+++ b/app/src/main/java/com/termux/api/MicRecorderAPI.java
@@ -31,10 +31,10 @@ public class MicRecorderAPI {
     /**
      * Starts our MicRecorder service
      */
-    static void onReceive(final Context context, final Intent intent) {
+    static void onReceive(final Context context, JSONObject opts) {
         Intent recorderService = new Intent(context, MicRecorderService.class);
-        recorderService.setAction(intent.getAction());
-        recorderService.putExtras(intent.getExtras());
+        recorderService.setAction(opts.optString("action"));
+        recorderService.putExtra("opts", opts.toString());
         context.startService(recorderService);
     }
 
@@ -92,7 +92,7 @@ public class MicRecorderAPI {
         protected static void postRecordCommandResult(final Context context, final Intent intent,
                                                       final RecorderCommandResult result) {
 
-            ResultReturner.returnData(context, intent, new ResultReturner.ResultWriter() {
+            ResultReturner.returnData(context, new ResultReturner.ResultWriter() {
                 @Override
                 public void writeResult(PrintWriter out) {
                     out.append(result.message + "\n");

--- a/app/src/main/java/com/termux/api/NotificationAPI.java
+++ b/app/src/main/java/com/termux/api/NotificationAPI.java
@@ -62,7 +62,7 @@ public class NotificationAPI {
 
         String title = opts.optString("title");
 
-        String lightsArgbExtra = opts.optString("led-color");
+        String lightsArgbExtra = opts.optString("led-color", null);
 
         int ledColor = 0;
 
@@ -79,10 +79,13 @@ public class NotificationAPI {
 
 
         JSONArray vibratePatternJson = opts.optJSONArray("vibrate");
-        long[] vibratePattern = new long[vibratePatternJson.length()];
+        long[] vibratePattern = null;
+        if(vibratePatternJson != null) {
+            vibratePattern = new long[vibratePatternJson.length()];
 
-        for(int i = 0; i < vibratePatternJson.length(); i++){
-            vibratePattern[i] = vibratePatternJson.optLong(i);
+            for (int i = 0; i < vibratePatternJson.length(); i++) {
+                vibratePattern[i] = vibratePatternJson.optLong(i);
+            }
         }
 
         boolean useSound = opts.optBoolean("sound", false);
@@ -91,7 +94,7 @@ public class NotificationAPI {
 
         String actionExtra = opts.optString("action");
 
-        String id = opts.optString("id");
+        String id = opts.optString("id", null);
         if (id == null) id = UUID.randomUUID().toString();
         final String notificationId = id;
 

--- a/app/src/main/java/com/termux/api/NotificationAPI.java
+++ b/app/src/main/java/com/termux/api/NotificationAPI.java
@@ -61,6 +61,7 @@ public class NotificationAPI {
         }
 
         String title = opts.optString("title");
+        String content = opts.optString("content");
 
         String lightsArgbExtra = opts.optString("led-color", null);
 
@@ -111,7 +112,7 @@ public class NotificationAPI {
 
 
 
-        String ImagePath = opts.optString("image-path");
+        String ImagePath = opts.optString("image-path", null);
 
         if(ImagePath != null){
             File imgFile = new  File(ImagePath);
@@ -191,31 +192,28 @@ public class NotificationAPI {
             notification.setDeleteIntent(pi);
         }
 
-        ResultReturner.returnData(context, new ResultReturner.WithStringInput() {
-            @Override
-            public void writeResult(PrintWriter out) {
-                NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
-                if (!TextUtils.isEmpty(inputString)) {
-                    if (inputString.contains("\n")) {
-                        Notification.BigTextStyle style = new Notification.BigTextStyle();
-                        style.bigText(inputString);
-                        notification.setStyle(style);
-                    } else {
-                        notification.setContentText(inputString);
-                    }
-                }
-
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
-                            CHANNEL_TITLE, NotificationManager.IMPORTANCE_DEFAULT);
-                    manager.createNotificationChannel(channel);
-                    notification.setChannelId(CHANNEL_ID);
-                }
-
-                manager.notify(notificationId, 0, notification.build());
+        if (!TextUtils.isEmpty(content)) {
+            if (content.contains("\n")) {
+                Notification.BigTextStyle style = new Notification.BigTextStyle();
+                style.bigText(content);
+                notification.setStyle(style);
+            } else {
+                notification.setContentText(content);
             }
-        });
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
+                    CHANNEL_TITLE, NotificationManager.IMPORTANCE_DEFAULT);
+            manager.createNotificationChannel(channel);
+            notification.setChannelId(CHANNEL_ID);
+        }
+
+        manager.notify(notificationId, 0, notification.build());
+        ResultReturner.noteDone(context);
+
     }
 
     static void onReceiveRemoveNotification(final Context context, JSONObject opts) {

--- a/app/src/main/java/com/termux/api/NotificationListAPI.java
+++ b/app/src/main/java/com/termux/api/NotificationListAPI.java
@@ -12,9 +12,9 @@ import com.termux.api.util.ResultReturner.ResultJsonWriter;
 
 public class NotificationListAPI {
 
-    public static void onReceive(TermuxApiReceiver apiReceiver, final Context context, Intent intent) {
+    public static void onReceive(final Context context) {
 
-        ResultReturner.returnData(apiReceiver, intent, new ResultJsonWriter() {
+        ResultReturner.returnData(context, new ResultJsonWriter() {
             @Override
             public void writeJson(JsonWriter out) throws Exception {
                 listNotifications(context, out);

--- a/app/src/main/java/com/termux/api/NotificationListAPI.java
+++ b/app/src/main/java/com/termux/api/NotificationListAPI.java
@@ -17,53 +17,50 @@ public class NotificationListAPI {
         ResultReturner.returnData(context, new ResultJsonWriter() {
             @Override
             public void writeJson(JsonWriter out) throws Exception {
-                listNotifications(context, out);
+                NotificationService notificationService = NotificationService.get();
+                StatusBarNotification[] notifications = notificationService.getActiveNotifications();
+
+                out.beginArray();
+                for (StatusBarNotification n : notifications) {
+                    int id = n.getId();
+                    String key = "";
+                    String title = "";
+                    String text = "";
+                    String packageName = "";
+                    String tag = "";
+                    String group = "";
+
+                    if (n.getNotification().extras.getCharSequence(Notification.EXTRA_TITLE) != null) {
+                        title = n.getNotification().extras.getCharSequence(Notification.EXTRA_TITLE).toString();
+                    }
+                    if (n.getNotification().extras.getCharSequence(Notification.EXTRA_TEXT) != null) {
+                        text = n.getNotification().extras.getCharSequence(Notification.EXTRA_TEXT).toString();
+                    }
+                    if (n.getTag() != null) {
+                        tag = n.getTag();
+                    }
+                    if (n.getNotification().getGroup() != null) {
+                        group = n.getNotification().getGroup();
+                    }
+                    if (n.getKey() != null) {
+                        key = n.getKey();
+                    }
+                    if (n.getPackageName() != null) {
+                        packageName = n.getPackageName();
+                    }
+                    out.beginObject()
+                            .name("id").value(id)
+                            .name("tag").value(tag)
+                            .name("key").value(key)
+                            .name("group").value(group)
+                            .name("packageName").value(packageName)
+                            .name("title").value(title)
+                            .name("content").value(text).endObject();
+                }
+                out.endArray();
             }
         });
     }
+}
 
 
-    static void listNotifications(Context context, JsonWriter out) throws Exception {
-        NotificationService notificationService = NotificationService.get();
-        StatusBarNotification[] notifications = notificationService.getActiveNotifications();
-
-        out.beginArray();
-        for (StatusBarNotification n : notifications) {
-            int id = n.getId();
-            String key = "";
-            String title = "";
-            String text = "";
-            String packageName = "";
-            String tag = "";
-            String group = "";
-
-            if (n.getNotification().extras.getCharSequence(Notification.EXTRA_TITLE) != null) {
-                title = n.getNotification().extras.getCharSequence(Notification.EXTRA_TITLE).toString();
-            }
-            if (n.getNotification().extras.getCharSequence(Notification.EXTRA_TEXT) != null) {
-                text = n.getNotification().extras.getCharSequence(Notification.EXTRA_TEXT).toString();
-            }
-            if (n.getTag() != null) {
-                tag = n.getTag();
-            }
-            if (n.getNotification().getGroup() != null) {
-                group = n.getNotification().getGroup();
-            }
-            if (n.getKey() != null) {
-                key = n.getKey();
-            }
-            if (n.getPackageName() != null) {
-                packageName = n.getPackageName();
-            }
-            out.beginObject()
-                    .name("id").value(id)
-                    .name("tag").value(tag)
-                    .name("key").value(key)
-                    .name("group").value(group)
-                    .name("packageName").value(packageName)
-                    .name("title").value(title)
-                    .name("content").value(text).endObject();
-        }
-        out.endArray();
-        }
-    }

--- a/app/src/main/java/com/termux/api/PhotoAPI.java
+++ b/app/src/main/java/com/termux/api/PhotoAPI.java
@@ -22,6 +22,8 @@ import android.view.WindowManager;
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.TermuxApiLogger;
 
+import org.json.JSONObject;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintWriter;
@@ -35,13 +37,13 @@ import java.util.Objects;
 
 public class PhotoAPI {
 
-    static void onReceive(TermuxApiReceiver apiReceiver, final Context context, Intent intent) {
-        final String filePath = intent.getStringExtra("file");
+    static void onReceive(final Context context, JSONObject opts) {
+        final String filePath = opts.optString("file");
         final File outputFile = new File(filePath);
         final File outputDir = outputFile.getParentFile();
-        final String cameraId = Objects.toString(intent.getStringExtra("camera"), "0");
+        final String cameraId = Objects.toString(opts.optString("camera"), "0");
 
-        ResultReturner.returnData(apiReceiver, intent, new ResultReturner.ResultWriter() {
+        ResultReturner.returnData(context, new ResultReturner.ResultWriter() {
             @Override
             public void writeResult(PrintWriter stdout) {
                 if (!(outputDir.isDirectory() || outputDir.mkdirs())) {

--- a/app/src/main/java/com/termux/api/SensorAPI.java
+++ b/app/src/main/java/com/termux/api/SensorAPI.java
@@ -32,10 +32,10 @@ public class SensorAPI {
     /**
      * Starts our SensorReader service
      */
-    public static void onReceive(final Context context, final Intent intent) {
+    public static void onReceive(final Context context, final JSONObject opts) {
         Intent serviceIntent = new Intent(context, SensorReaderService.class);
-        serviceIntent.setAction(intent.getAction());
-        serviceIntent.putExtras(intent.getExtras());
+        serviceIntent.setAction(opts.optString("action"));
+        serviceIntent.putExtra("opts", opts.toString());
         context.startService(serviceIntent);
     }
 
@@ -161,7 +161,7 @@ public class SensorAPI {
         private void postSensorCommandResult(final Context context, final Intent intent,
                                              final SensorCommandResult result) {
 
-            ResultReturner.returnData(context, intent, new ResultReturner.ResultWriter() {
+            ResultReturner.returnData(context, new ResultReturner.ResultWriter() {
                 @Override
                 public void writeResult(PrintWriter out) {
                     out.append(result.message + "\n");

--- a/app/src/main/java/com/termux/api/ShareAPI.java
+++ b/app/src/main/java/com/termux/api/ShareAPI.java
@@ -14,18 +14,20 @@ import android.webkit.MimeTypeMap;
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.TermuxApiLogger;
 
+import org.json.JSONObject;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 
 public class ShareAPI {
 
-    static void onReceive(TermuxApiReceiver apiReceiver, final Context context, final Intent intent) {
-        final String fileExtra = intent.getStringExtra("file");
-        final String titleExtra = intent.getStringExtra("title");
-        final String contentTypeExtra = intent.getStringExtra("content-type");
-        final boolean defaultReceiverExtra = intent.getBooleanExtra("default-receiver", false);
-        final String actionExtra = intent.getStringExtra("action");
+    static void onReceive(final Context context, JSONObject opts) {
+        final String fileExtra = opts.optString("file");
+        final String titleExtra = opts.optString("title");
+        final String contentTypeExtra = opts.optString("content-type");
+        final boolean defaultReceiverExtra = opts.optBoolean("default-receiver", false);
+        final String actionExtra = opts.optString("action");
 
         String intentAction = null;
         if (actionExtra == null) {
@@ -50,7 +52,7 @@ public class ShareAPI {
 
         if (fileExtra == null) {
             // Read text to share from stdin.
-            ResultReturner.returnData(apiReceiver, intent, new ResultReturner.WithStringInput() {
+            ResultReturner.returnData(context, new ResultReturner.WithStringInput() {
                 @Override
                 public void writeResult(PrintWriter out) {
                     if (TextUtils.isEmpty(inputString)) {
@@ -72,7 +74,7 @@ public class ShareAPI {
             });
         } else {
             // Share specified file.
-            ResultReturner.returnData(apiReceiver, intent, new ResultReturner.ResultWriter() {
+            ResultReturner.returnData(context, new ResultReturner.ResultWriter() {
                 @Override
                 public void writeResult(PrintWriter out) {
                     final File fileToShare = new File(fileExtra);

--- a/app/src/main/java/com/termux/api/SmsInboxAPI.java
+++ b/app/src/main/java/com/termux/api/SmsInboxAPI.java
@@ -14,6 +14,8 @@ import android.util.JsonWriter;
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.ResultReturner.ResultJsonWriter;
 
+import org.json.JSONObject;
+
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -24,12 +26,12 @@ public class SmsInboxAPI {
 
     private static final String[] DISPLAY_NAME_PROJECTION = {PhoneLookup.DISPLAY_NAME};
 
-    static void onReceive(TermuxApiReceiver apiReceiver, final Context context, Intent intent) {
-        final int offset = intent.getIntExtra("offset", 0);
-        final int limit = intent.getIntExtra("limit", 50);
-        final Uri contentURI = typeToContentURI(intent.getIntExtra("type", TextBasedSmsColumns.MESSAGE_TYPE_INBOX));
+    static void onReceive(final Context context, JSONObject opts) {
+        final int offset = opts.optInt("offset", 0);
+        final int limit = opts.optInt("limit", 50);
+        final Uri contentURI = typeToContentURI(opts.optInt("type", TextBasedSmsColumns.MESSAGE_TYPE_INBOX));
 
-        ResultReturner.returnData(apiReceiver, intent, new ResultJsonWriter() {
+        ResultReturner.returnData(context, new ResultJsonWriter() {
             @Override
             public void writeJson(JsonWriter out) throws Exception {
                 getAllSms(context, out, offset, limit, contentURI);

--- a/app/src/main/java/com/termux/api/SmsSendAPI.java
+++ b/app/src/main/java/com/termux/api/SmsSendAPI.java
@@ -1,26 +1,34 @@
 package com.termux.api;
 
+import android.content.Context;
 import android.content.Intent;
 import android.telephony.SmsManager;
 
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.TermuxApiLogger;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 
 public class SmsSendAPI {
 
-    static void onReceive(TermuxApiReceiver apiReceiver, final Intent intent) {
-        ResultReturner.returnData(apiReceiver, intent, new ResultReturner.WithStringInput() {
+    static void onReceive(Context context, final JSONObject opts) {
+        ResultReturner.returnData(context, new ResultReturner.WithStringInput() {
             @Override
             public void writeResult(PrintWriter out) {
                 final SmsManager smsManager = SmsManager.getDefault();
-                String[] recipients = intent.getStringArrayExtra("recipients");
+                JSONArray recipientsJson = opts.optJSONArray("recipients");
+                String[] recipients = new String[recipientsJson.length()];
+                for(int i = 0; i < recipientsJson.length(); i++){
+                    recipients[i] = recipientsJson.optString(i);
+                }
 
                 if (recipients == null) {
                     // Used by old versions of termux-send-sms.
-                    String recipient = intent.getStringExtra("recipient");
+                    String recipient = opts.optString("recipient");
                     if (recipient != null) recipients = new String[]{recipient};
                 }
 

--- a/app/src/main/java/com/termux/api/SpeechToTextAPI.java
+++ b/app/src/main/java/com/termux/api/SpeechToTextAPI.java
@@ -17,6 +17,8 @@ import android.speech.SpeechRecognizer;
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.TermuxApiLogger;
 
+import org.json.JSONObject;
+
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -156,7 +158,7 @@ public class SpeechToTextAPI {
         @Override
         protected void onHandleIntent(final Intent intent) {
             TermuxApiLogger.error("onHandleIntent");
-            ResultReturner.returnData(this, intent, new ResultReturner.WithInput() {
+            ResultReturner.returnData(this, new ResultReturner.WithInput() {
                 @Override
                 public void writeResult(PrintWriter out) throws Exception {
                     while (true) {
@@ -173,8 +175,8 @@ public class SpeechToTextAPI {
         }
     }
 
-    public static void onReceive(final Context context, Intent intent) {
-        context.startService(new Intent(context, SpeechToTextService.class).putExtras(intent.getExtras()));
+    public static void onReceive(final Context context, JSONObject opts) {
+        context.startService(new Intent(context, SpeechToTextService.class).putExtra("opts", opts.toString()));
     }
 
     public static void runFromActivity(final Activity context) {

--- a/app/src/main/java/com/termux/api/StorageGetAPI.java
+++ b/app/src/main/java/com/termux/api/StorageGetAPI.java
@@ -8,6 +8,8 @@ import android.net.Uri;
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.TermuxApiLogger;
 
+import org.json.JSONObject;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -19,11 +21,11 @@ public class StorageGetAPI {
 
     private static final String FILE_EXTRA = "com.termux.api.storage.file";
 
-    static void onReceive(TermuxApiReceiver apiReceiver, final Context context, final Intent intent) {
-        ResultReturner.returnData(apiReceiver, intent, new ResultReturner.ResultWriter() {
+    static void onReceive(final Context context, final JSONObject opts) {
+        ResultReturner.returnData(context, new ResultReturner.ResultWriter() {
             @Override
             public void writeResult(PrintWriter out) {
-                final String fileExtra = intent.getStringExtra("file");
+                final String fileExtra = opts.optString("file");
                 if (fileExtra == null || !new File(fileExtra).getParentFile().canWrite()) {
                     out.println("ERROR: Not a writable folder: " + fileExtra);
                     return;

--- a/app/src/main/java/com/termux/api/TelephonyAPI.java
+++ b/app/src/main/java/com/termux/api/TelephonyAPI.java
@@ -16,6 +16,8 @@ import android.util.Log;
 
 import com.termux.api.util.ResultReturner;
 
+import org.json.JSONObject;
+
 import java.io.IOException;
 
 /**
@@ -27,8 +29,8 @@ public class TelephonyAPI {
         if (value != Integer.MAX_VALUE) out.name(name).value(value);
     }
 
-    static void onReceiveTelephonyCellInfo(TermuxApiReceiver apiReceiver, final Context context, final Intent intent) {
-        ResultReturner.returnData(apiReceiver, intent, new ResultReturner.ResultJsonWriter() {
+    static void onReceiveTelephonyCellInfo(final Context context) {
+        ResultReturner.returnData(context, new ResultReturner.ResultJsonWriter() {
             @Override
             public void writeJson(JsonWriter out) throws Exception {
                 TelephonyManager manager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
@@ -109,8 +111,8 @@ public class TelephonyAPI {
     }
 
 
-    static void onReceiveTelephonyDeviceInfo(TermuxApiReceiver apiReceiver, final Context context, final Intent intent) {
-        ResultReturner.returnData(apiReceiver, intent, new ResultReturner.ResultJsonWriter() {
+    static void onReceiveTelephonyDeviceInfo(final Context context) {
+        ResultReturner.returnData(context, new ResultReturner.ResultJsonWriter() {
             @SuppressLint("HardwareIds")
             @Override
             public void writeJson(JsonWriter out) throws Exception {
@@ -295,11 +297,11 @@ public class TelephonyAPI {
         });
     }
 
-    static void onReceiveTelephonyCall(TermuxApiReceiver apiReceiver, final Context context, final Intent intent) {
-        String numberExtra = intent.getStringExtra("number");
+    static void onReceiveTelephonyCall(final Context context, JSONObject opts) {
+        String numberExtra = opts.optString("number");
         if (numberExtra == null) {
             Log.e("termux-api", "No 'number extra");
-            ResultReturner.noteDone(apiReceiver, intent);
+            ResultReturner.noteDone(context);
         }
 
         Uri data = Uri.parse("tel:" + numberExtra);
@@ -314,7 +316,7 @@ public class TelephonyAPI {
             Log.e("termux-api", "Exception in phone call", e);
         }
 
-        ResultReturner.noteDone(apiReceiver, intent);
+        ResultReturner.noteDone(context);
     }
 
 }

--- a/app/src/main/java/com/termux/api/TermuxApiReceiver.java
+++ b/app/src/main/java/com/termux/api/TermuxApiReceiver.java
@@ -1,194 +1,21 @@
 package com.termux.api;
 
-import android.Manifest;
 import android.content.BroadcastReceiver;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-import android.provider.Settings;
-import android.widget.Toast;
-
-import com.termux.api.util.TermuxApiLogger;
-import com.termux.api.util.TermuxApiPermissionActivity;
 
 public class TermuxApiReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        String apiMethod = intent.getStringExtra("api_method");
-        if (apiMethod == null) {
-            TermuxApiLogger.error("Missing 'api_method' extra");
-            return;
-        }
 
-        switch (apiMethod) {
-            case "AudioInfo":
-                AudioAPI.onReceive(this, context, intent);
-                break;
-            case "BatteryStatus":
-                BatteryStatusAPI.onReceive(this, context, intent);
-                break;
-            case "Brightness":
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    if (!Settings.System.canWrite(context)) {
-                        TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.WRITE_SETTINGS);
-                        Toast.makeText(context, "Please enable permission for Termux:API", Toast.LENGTH_LONG).show();
+        Intent myService = new Intent(context, TermuxApiService.class);
 
-                        // user must enable WRITE_SETTINGS permission this special way
-                        Intent settingsIntent = new Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS);
-                        context.startActivity(settingsIntent);
-                        return;
-                    }
-                }
-                BrightnessAPI.onReceive(this, context, intent);
-                break;
-            case "CameraInfo":
-                CameraInfoAPI.onReceive(this, context, intent);
-                break;
-            case "CameraPhoto":
-                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.CAMERA)) {
-                    PhotoAPI.onReceive(this, context, intent);
-                }
-                break;
-            case "CallLog":
-                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.READ_CALL_LOG)) {
-                    CallLogAPI.onReceive(context, intent);
-                }
-                break;
-            case "Clipboard":
-                ClipboardAPI.onReceive(this, context, intent);
-                break;
-            case "ContactList":
-                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.READ_CONTACTS)) {
-                    ContactListAPI.onReceive(this, context, intent);
-                }
-                break;
-            case "Dialog":
-                context.startActivity(new Intent(context, DialogActivity.class).putExtras(intent.getExtras()).addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK));
-                break;
-            case "Download":
-                DownloadAPI.onReceive(this, context, intent);
-                break;
-            case "Fingerprint":
-                FingerprintAPI.onReceive(context, intent);
-                break;
-            case "InfraredFrequencies":
-                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.TRANSMIT_IR)) {
-                    InfraredAPI.onReceiveCarrierFrequency(this, context, intent);
-                }
-                break;
-            case "InfraredTransmit":
-                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.TRANSMIT_IR)) {
-                    InfraredAPI.onReceiveTransmit(this, context, intent);
-                }
-                break;
-            case "Keystore":
-                KeystoreAPI.onReceive(this, intent);
-                break;
-            case "Location":
-                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.ACCESS_FINE_LOCATION)) {
-                    LocationAPI.onReceive(this, context, intent);
-                }
-                break;
-            case "MediaPlayer":
-                MediaPlayerAPI.onReceive(context, intent);
-                break;
-            case "MediaScanner":
-                MediaScannerAPI.onReceive(this, context, intent);
-                break;
-            case "MicRecorder":
-                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.RECORD_AUDIO)) {
-                    MicRecorderAPI.onReceive(context, intent);
-                }
-                break;
-            case "NotificationList":
-                ComponentName cn = new ComponentName(context, NotificationService.class);
-                String flat = Settings.Secure.getString(context.getContentResolver(), "enabled_notification_listeners");
-                final boolean NotificationServiceEnabled = flat != null && flat.contains(cn.flattenToString());
-                if (!NotificationServiceEnabled) {
-                    Toast.makeText(context,"Please give Termux:API Notification Access", Toast.LENGTH_LONG).show();
-                    context.startActivity(new Intent("android.settings.ACTION_NOTIFICATION_LISTENER_SETTINGS"));
-                } else {
-                    NotificationListAPI.onReceive(this, context, intent);
-                }
-                break;
-            case "Notification":
-                NotificationAPI.onReceiveShowNotification(this, context, intent);
-                break;
-            case "NotificationRemove":
-                NotificationAPI.onReceiveRemoveNotification(this, context, intent);
-                break;
-            case "Sensor":
-                SensorAPI.onReceive(context, intent);
-                break;
-            case "Share":
-                ShareAPI.onReceive(this, context, intent);
-                break;
-            case "SmsInbox":
-                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.READ_SMS, Manifest.permission.READ_CONTACTS)) {
-                    SmsInboxAPI.onReceive(this, context, intent);
-                }
-                break;
-            case "SmsSend":
-                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.SEND_SMS)) {
-                    SmsSendAPI.onReceive(this, intent);
-                }
-                break;
-            case "StorageGet":
-                StorageGetAPI.onReceive(this, context, intent);
-                break;
-            case "SpeechToText":
-                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.RECORD_AUDIO)) {
-                    SpeechToTextAPI.onReceive(context, intent);
-                }
-                break;
-            case "TelephonyCall":
-                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.CALL_PHONE)) {
-                    TelephonyAPI.onReceiveTelephonyCall(this, context, intent);
-                }
-                break;
-            case "TelephonyCellInfo":
-                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.ACCESS_COARSE_LOCATION)) {
-                    TelephonyAPI.onReceiveTelephonyCellInfo(this, context, intent);
-                }
-                break;
-            case "TelephonyDeviceInfo":
-                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.READ_PHONE_STATE)) {
-                    TelephonyAPI.onReceiveTelephonyDeviceInfo(this, context, intent);
-                }
-                break;
-            case "TextToSpeech":
-                TextToSpeechAPI.onReceive(context, intent);
-                break;
-            case "Toast":
-                ToastAPI.onReceive(context, intent);
-                break;
-            case "Torch":
-                TorchAPI.onReceive(this, context, intent);
-                break;
-            case "Vibrate":
-                VibrateAPI.onReceive(this, context, intent);
-                break;
-            case "Volume":
-                VolumeAPI.onReceive(this, context, intent);
-                break;
-            case "Wallpaper":
-                WallpaperAPI.onReceive(context, intent);
-                break;
-            case "WifiConnectionInfo":
-                WifiAPI.onReceiveWifiConnectionInfo(this, context, intent);
-                break;
-            case "WifiScanInfo":
-                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.ACCESS_FINE_LOCATION)) {
-                    WifiAPI.onReceiveWifiScanInfo(this, context, intent);
-                }
-                break;
-            case "WifiEnable":
-                WifiAPI.onReceiveWifiEnable(this, context, intent);
-                break;
-            default:
-                TermuxApiLogger.error("Unrecognized 'api_method' extra: '" + apiMethod + "'");
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(myService);
+        } else {
+            context.startService(myService);
         }
     }
 

--- a/app/src/main/java/com/termux/api/TermuxApiService.java
+++ b/app/src/main/java/com/termux/api/TermuxApiService.java
@@ -60,7 +60,6 @@ public class TermuxApiService extends Service {
                             }
                             recievedData = new String(baos.toByteArray(), StandardCharsets.UTF_8);
                             receiver.close();
-                            Log.d("DERP", "onStartCommand: " + recievedData);
                             JSONObject data = new JSONObject(recievedData);
                             runApiMethod(getApplicationContext(), data);
                         }

--- a/app/src/main/java/com/termux/api/TermuxApiService.java
+++ b/app/src/main/java/com/termux/api/TermuxApiService.java
@@ -18,6 +18,7 @@ import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 import android.widget.Toast;
 
+import com.termux.api.util.ResultReturner;
 import com.termux.api.util.TermuxApiLogger;
 import com.termux.api.util.TermuxApiPermissionActivity;
 
@@ -92,7 +93,7 @@ public class TermuxApiService extends Service {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     if (!Settings.System.canWrite(context)) {
                         TermuxApiPermissionActivity.checkAndRequestPermissions(context, android.Manifest.permission.WRITE_SETTINGS);
-                        Toast.makeText(context, "Please enable permission for Termux:API", Toast.LENGTH_LONG).show();
+                        ToastAPI.makeText(context, "Please enable permission for Termux:API", Toast.LENGTH_LONG);
 
                         //user must enable WRITE_SETTINGS permission this special way
                         Intent settingsIntent = new Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS);
@@ -166,8 +167,9 @@ public class TermuxApiService extends Service {
                 String flat = Settings.Secure.getString(context.getContentResolver(), "enabled_notification_listeners");
                 final boolean NotificationServiceEnabled = flat != null && flat.contains(cn.flattenToString());
                 if (!NotificationServiceEnabled) {
-                    Toast.makeText(context, "Please give Termux:API Notification Access", Toast.LENGTH_LONG).show();
+                    ToastAPI.makeText(context, "Please give Termux:API Notification Access", Toast.LENGTH_LONG);
                     context.startActivity(new Intent("android.settings.ACTION_NOTIFICATION_LISTENER_SETTINGS"));
+                    ResultReturner.noteDone(context);
                 } else {
                     NotificationListAPI.onReceive(context);
                 }

--- a/app/src/main/java/com/termux/api/TermuxApiService.java
+++ b/app/src/main/java/com/termux/api/TermuxApiService.java
@@ -30,9 +30,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 public class TermuxApiService extends Service {
-    private static final String CHANNEL_ID = "termux-notification";
-    private static final String CHANNEL_TITLE = "Termux API notification channel";
-
     public IBinder onBind(Intent intent) {
         return null;
     }
@@ -45,7 +42,7 @@ public class TermuxApiService extends Service {
         final Runnable runnable = new Runnable() {
             @Override
             public void run() {
-                String recievedData;
+                String receivedData;
                 while (true) {
                     try (LocalServerSocket inputSocket = new LocalServerSocket(SOCKET_INPUT_ADDRESS)) {
                         LocalSocket receiver = inputSocket.accept();
@@ -58,9 +55,9 @@ public class TermuxApiService extends Service {
                             while ((l = input.read(buffer)) > 0) {
                                 baos.write(buffer, 0, l);
                             }
-                            recievedData = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+                            receivedData = new String(baos.toByteArray(), StandardCharsets.UTF_8);
                             receiver.close();
-                            JSONObject data = new JSONObject(recievedData);
+                            JSONObject data = new JSONObject(receivedData);
                             runApiMethod(getApplicationContext(), data);
                         }
                     } catch(IOException e){
@@ -277,7 +274,7 @@ public class TermuxApiService extends Service {
         } else {
             NotificationCompat.Builder builder = new NotificationCompat.Builder(this)
                     .setContentTitle(getString(R.string.app_name))
-                    .setContentText("TERNYX")
+                    .setContentText("Termux")
                     .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                     .setAutoCancel(true);
             Notification notification = builder.build();

--- a/app/src/main/java/com/termux/api/TermuxApiService.java
+++ b/app/src/main/java/com/termux/api/TermuxApiService.java
@@ -1,0 +1,294 @@
+package com.termux.api;
+
+import android.Manifest;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.net.LocalServerSocket;
+import android.net.LocalSocket;
+import android.os.Build;
+import android.os.IBinder;
+import android.provider.Settings;
+import android.support.v4.app.NotificationCompat;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.termux.api.util.TermuxApiLogger;
+import com.termux.api.util.TermuxApiPermissionActivity;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class TermuxApiService extends Service {
+    private static final String CHANNEL_ID = "termux-notification";
+    private static final String CHANNEL_TITLE = "Termux API notification channel";
+
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onCreate() {
+        final String SOCKET_INPUT_ADDRESS = "termux-input";
+
+
+        final Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                while (true) {
+                    try (LocalServerSocket inputSocket = new LocalServerSocket(SOCKET_INPUT_ADDRESS)) {
+                        LocalSocket receiver = inputSocket.accept();
+                        if (receiver != null) {
+                            InputStream input = receiver.getInputStream();
+                            int readed = input.read();
+                            int size = 0;
+                            int capacity = 0;
+                            byte[] bytes = new byte[capacity];
+
+                            while (readed != -1) {
+                                capacity = (capacity * 3) / 2 + 1;
+                                byte[] copy = new byte[capacity];
+                                System.arraycopy(bytes, 0, copy, 0, bytes.length);
+                                bytes = copy;
+                                bytes[size++] = (byte) readed;
+                                readed = input.read();
+                            }
+
+                            String recievedData = new String(bytes, 0, size);
+                            receiver.close();
+                            Log.d("DERP", "onStartCommand: " + recievedData);
+                            JSONObject data = new JSONObject(recievedData);
+                            runApiMethod(getApplicationContext(), data);
+                        }
+                    } catch(IOException e){
+                        e.printStackTrace();
+                    } catch(JSONException e){
+                        TermuxApiLogger.error("Not valid JSON");
+                    }
+                }
+            }
+        };
+
+        new Thread(runnable).start();
+        super.onCreate();
+    }
+
+    public void runApiMethod(final Context context, JSONObject data) {
+        String apiMethod = data.optString("api_method");
+
+        if (apiMethod == null) {
+            TermuxApiLogger.error("Missing 'api_method' extra");
+            return;
+        }
+
+        switch (apiMethod) {
+            case "AudioInfo":
+                AudioAPI.onReceive(context);
+                break;
+            case "BatteryStatus":
+                BatteryStatusAPI.onReceive(context);
+                break;
+            case "Brightness":
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    if (!Settings.System.canWrite(context)) {
+                        TermuxApiPermissionActivity.checkAndRequestPermissions(context, android.Manifest.permission.WRITE_SETTINGS);
+                        Toast.makeText(context, "Please enable permission for Termux:API", Toast.LENGTH_LONG).show();
+
+                        //user must enable WRITE_SETTINGS permission this special way
+                        Intent settingsIntent = new Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS);
+                        context.startActivity(settingsIntent);
+                        return;
+                    }
+                }
+                BrightnessAPI.onReceive(context, data);
+                break;
+            case "CameraInfo":
+                CameraInfoAPI.onReceive(context);
+                break;
+            case "CameraPhoto":
+                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, android.Manifest.permission.CAMERA)) {
+                    PhotoAPI.onReceive(context, data);
+                }
+                break;
+            case "CallLog":
+                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, android.Manifest.permission.READ_CALL_LOG)) {
+                    CallLogAPI.onReceive(context, data);
+                }
+                break;
+            case "Clipboard":
+                ClipboardAPI.onReceive(context, data);
+                break;
+            case "ContactList":
+                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, android.Manifest.permission.READ_CONTACTS)) {
+                    ContactListAPI.onReceive(context);
+                }
+                break;
+            case "Dialog":
+                context.startActivity(new Intent(context, DialogActivity.class).putExtra("data", data.toString()).addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK));
+                break;
+            case "Download":
+                DownloadAPI.onReceive(context, data);
+                break;
+            case "Fingerprint":
+                FingerprintAPI.onReceive(context, data);
+                break;
+            case "InfraredFrequencies":
+                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, android.Manifest.permission.TRANSMIT_IR)) {
+                    InfraredAPI.onReceiveCarrierFrequency(context);
+                }
+                break;
+            case "InfraredTransmit":
+                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, android.Manifest.permission.TRANSMIT_IR)) {
+                    InfraredAPI.onReceiveTransmit(context, data);
+                }
+                break;
+            case "Keystore":
+                KeystoreAPI.onReceive(this, data);
+                break;
+            case "Location":
+                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, android.Manifest.permission.ACCESS_FINE_LOCATION)) {
+                    LocationAPI.onReceive(context, data);
+                }
+                break;
+            case "MediaPlayer":
+                MediaPlayerAPI.onReceive(context, data);
+                break;
+            case "MediaScanner":
+                MediaScannerAPI.onReceive(context, data);
+                break;
+            case "MicRecorder":
+                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, android.Manifest.permission.RECORD_AUDIO)) {
+                    MicRecorderAPI.onReceive(context, data);
+                }
+                break;
+            case "NotificationList":
+                ComponentName cn = new ComponentName(context, NotificationService.class);
+                String flat = Settings.Secure.getString(context.getContentResolver(), "enabled_notification_listeners");
+                final boolean NotificationServiceEnabled = flat != null && flat.contains(cn.flattenToString());
+                if (!NotificationServiceEnabled) {
+                    Toast.makeText(context, "Please give Termux:API Notification Access", Toast.LENGTH_LONG).show();
+                    context.startActivity(new Intent("android.settings.ACTION_NOTIFICATION_LISTENER_SETTINGS"));
+                } else {
+                    NotificationListAPI.onReceive(context);
+                }
+                break;
+            case "Notification":
+                NotificationAPI.onReceiveShowNotification(context, data);
+                break;
+            case "NotificationRemove":
+                NotificationAPI.onReceiveRemoveNotification(context, data);
+                break;
+            case "Sensor":
+                SensorAPI.onReceive(context, data);
+                break;
+            case "Share":
+                ShareAPI.onReceive(context, data);
+                break;
+            case "SmsInbox":
+                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, android.Manifest.permission.READ_SMS, android.Manifest.permission.READ_CONTACTS)) {
+                    SmsInboxAPI.onReceive(context, data);
+                }
+                break;
+            case "SmsSend":
+                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, android.Manifest.permission.SEND_SMS)) {
+                    SmsSendAPI.onReceive(context, data);
+                }
+                break;
+            case "StorageGet":
+                StorageGetAPI.onReceive(context, data);
+                break;
+            case "SpeechToText":
+                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, android.Manifest.permission.RECORD_AUDIO)) {
+                    SpeechToTextAPI.onReceive(context, data);
+                }
+                break;
+            case "TelephonyCall":
+                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, android.Manifest.permission.CALL_PHONE)) {
+                    TelephonyAPI.onReceiveTelephonyCall(context, data);
+                }
+                break;
+            case "TelephonyCellInfo":
+                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, android.Manifest.permission.ACCESS_COARSE_LOCATION)) {
+                    TelephonyAPI.onReceiveTelephonyCellInfo(context);
+                }
+                break;
+            case "TelephonyDeviceInfo":
+                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, android.Manifest.permission.READ_PHONE_STATE)) {
+                    TelephonyAPI.onReceiveTelephonyDeviceInfo(context);
+                }
+                break;
+            case "TextToSpeech":
+                TextToSpeechAPI.onReceive(context, data);
+                break;
+            case "Toast":
+                ToastAPI.onReceive(context, data);
+                break;
+            case "Torch":
+                TorchAPI.onReceive(context, data);
+                break;
+            case "Vibrate":
+                VibrateAPI.onReceive(context, data);
+                break;
+            case "Volume":
+                VolumeAPI.onReceive(context, data);
+                break;
+            case "Wallpaper":
+                WallpaperAPI.onReceive(context, data);
+                break;
+            case "WifiConnectionInfo":
+                WifiAPI.onReceiveWifiConnectionInfo(context);
+                break;
+            case "WifiScanInfo":
+                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, Manifest.permission.ACCESS_FINE_LOCATION)) {
+                    WifiAPI.onReceiveWifiScanInfo(context);
+                }
+                break;
+            case "WifiEnable":
+                WifiAPI.onReceiveWifiEnable(context, data);
+                break;
+            default:
+                TermuxApiLogger.error("Unrecognized 'api_method' extra: '" + apiMethod + "'");
+        }
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            String NOTIFICATION_CHANNEL_ID = "Termux-Notification";
+            String channelName = "Termux";
+            NotificationChannel chan = new NotificationChannel(NOTIFICATION_CHANNEL_ID, channelName, NotificationManager.IMPORTANCE_NONE);
+
+            NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+            assert manager != null;
+            manager.createNotificationChannel(chan);
+
+            Notification.Builder builder = new Notification.Builder(this, NOTIFICATION_CHANNEL_ID)
+                    .setContentTitle(getString(R.string.app_name))
+                    .setOngoing(true)
+                    .setPriority(Notification.PRIORITY_MIN)
+                    .setCategory(Notification.CATEGORY_SERVICE)
+                    .setAutoCancel(true);
+
+            Notification notification = builder.build();
+            startForeground(1, notification);
+        } else {
+            NotificationCompat.Builder builder = new NotificationCompat.Builder(this)
+                    .setContentTitle(getString(R.string.app_name))
+                    .setContentText("TERNYX")
+                    .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                    .setAutoCancel(true);
+            Notification notification = builder.build();
+            startForeground(1, notification);
+        }
+        return super.onStartCommand(intent, flags, startId);
+    }
+
+}

--- a/app/src/main/java/com/termux/api/TextToSpeechAPI.java
+++ b/app/src/main/java/com/termux/api/TextToSpeechAPI.java
@@ -15,6 +15,8 @@ import android.util.JsonWriter;
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.TermuxApiLogger;
 
+import org.json.JSONObject;
+
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
@@ -25,8 +27,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class TextToSpeechAPI {
 
-    public static void onReceive(final Context context, Intent intent) {
-        context.startService(new Intent(context, TextToSpeechService.class).putExtras(intent.getExtras()));
+    public static void onReceive(final Context context, JSONObject opts) {
+        context.startService(new Intent(context, TextToSpeechService.class).putExtra("opts", opts.toString()));
     }
 
     public static class TextToSpeechService extends IntentService {
@@ -92,7 +94,7 @@ public class TextToSpeechAPI {
                 }
             }, speechEngine);
 
-            ResultReturner.returnData(this, intent, new ResultReturner.WithInput() {
+            ResultReturner.returnData(this, new ResultReturner.WithInput() {
                 @Override
                 public void writeResult(PrintWriter out) {
 

--- a/app/src/main/java/com/termux/api/ToastAPI.java
+++ b/app/src/main/java/com/termux/api/ToastAPI.java
@@ -27,25 +27,37 @@ public class ToastAPI extends AppCompatActivity {
         final int gravity = getGravity(opts);
         final String text = opts.optString("text");
 
+        makeToast(context, durationExtra, backgroundColor, textColor, gravity, text);
+        ResultReturner.noteDone(context);
+    }
+
+    static void makeText(final Context context, final String text, final int durationExtra) {
+        final int backgroundColor = Color.GRAY;
+        final int textColor = Color.WHITE;
+        final int gravity = Gravity.BOTTOM;
+        makeToast(context, durationExtra, backgroundColor, textColor, gravity, text);
+    }
+
+        static void makeToast(final Context context, final int durationExtra, final int backgroundColor, final int textColor, final int gravity, final String text) {
         final Handler handler = new Handler(Looper.getMainLooper());
 
-                handler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        Toast toast = Toast.makeText(context, text, durationExtra);
-                        View toastView = toast.getView();
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                Toast toast = Toast.makeText(context, text, durationExtra);
+                View toastView = toast.getView();
 
-                        Drawable background = toastView.getBackground();
-                        background.setTint(backgroundColor);
+                Drawable background = toastView.getBackground();
+                background.setTint(backgroundColor);
 
-                        TextView textView = toastView.findViewById(android.R.id.message);
-                        textView.setTextColor(textColor);
+                TextView textView = toastView.findViewById(android.R.id.message);
+                textView.setTextColor(textColor);
 
-                        toast.setGravity(gravity, 0, 0);
-                        toast.show();
-                        ResultReturner.noteDone(context);
-                    }
-                });
+                toast.setGravity(gravity, 0, 0);
+                toast.show();
+            }
+        });
+
     }
 
     protected static int getColor(JSONObject opts, String extra, int defaultColor) {

--- a/app/src/main/java/com/termux/api/ToastAPI.java
+++ b/app/src/main/java/com/termux/api/ToastAPI.java
@@ -13,19 +13,21 @@ import android.widget.Toast;
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.TermuxApiLogger;
 
+import org.json.JSONObject;
+
 import java.io.PrintWriter;
 
 public class ToastAPI {
 
-    public static void onReceive(final Context context, Intent intent) {
-        final int durationExtra = intent.getBooleanExtra("short", false) ? Toast.LENGTH_SHORT : Toast.LENGTH_LONG;
-        final int backgroundColor = getColorExtra(intent, "background", Color.GRAY);
-        final int textColor = getColorExtra(intent, "text_color", Color.WHITE);
-        final int gravity = getGravityExtra(intent);
+    public static void onReceive(final Context context, JSONObject opts) {
+        final int durationExtra = opts.optBoolean("short", false) ? Toast.LENGTH_SHORT : Toast.LENGTH_LONG;
+        final int backgroundColor = getColor(opts, "background", Color.GRAY);
+        final int textColor = getColor(opts, "text_color", Color.WHITE);
+        final int gravity = getGravity(opts);
 
         final Handler handler = new Handler();
 
-        ResultReturner.returnData(context, intent, new ResultReturner.WithStringInput() {
+        ResultReturner.returnData(context, new ResultReturner.WithStringInput() {
             @Override
             public void writeResult(PrintWriter out) {
                 handler.post(new Runnable() {
@@ -48,11 +50,11 @@ public class ToastAPI {
         });
     }
 
-    protected static int getColorExtra(Intent intent, String extra, int defaultColor) {
+    protected static int getColor(JSONObject opts, String extra, int defaultColor) {
         int color = defaultColor;
 
-        if (intent.hasExtra(extra)) {
-            String colorExtra = intent.getStringExtra(extra);
+        if (!opts.isNull(extra)) {
+            String colorExtra = opts.optString(extra);
 
             try {
                 color = Color.parseColor(colorExtra);
@@ -63,8 +65,8 @@ public class ToastAPI {
         return color;
     }
 
-    protected static int getGravityExtra(Intent intent) {
-        String extraGravity = intent.getStringExtra("gravity");
+    protected static int getGravity(JSONObject opts) {
+        String extraGravity = opts.optString("gravity");
 
         switch (extraGravity == null ? "" : extraGravity) {
             case "top": return Gravity.TOP;
@@ -73,5 +75,6 @@ public class ToastAPI {
             default: return Gravity.CENTER;
         }
     }
+
 
 }

--- a/app/src/main/java/com/termux/api/ToastAPI.java
+++ b/app/src/main/java/com/termux/api/ToastAPI.java
@@ -5,6 +5,8 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Handler;
+import android.os.Looper;
+import android.support.v7.app.AppCompatActivity;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.TextView;
@@ -17,23 +19,20 @@ import org.json.JSONObject;
 
 import java.io.PrintWriter;
 
-public class ToastAPI {
-
+public class ToastAPI extends AppCompatActivity {
     public static void onReceive(final Context context, JSONObject opts) {
         final int durationExtra = opts.optBoolean("short", false) ? Toast.LENGTH_SHORT : Toast.LENGTH_LONG;
         final int backgroundColor = getColor(opts, "background", Color.GRAY);
         final int textColor = getColor(opts, "text_color", Color.WHITE);
         final int gravity = getGravity(opts);
+        final String text = opts.optString("text");
 
-        final Handler handler = new Handler();
+        final Handler handler = new Handler(Looper.getMainLooper());
 
-        ResultReturner.returnData(context, new ResultReturner.WithStringInput() {
-            @Override
-            public void writeResult(PrintWriter out) {
                 handler.post(new Runnable() {
                     @Override
                     public void run() {
-                        Toast toast = Toast.makeText(context, inputString, durationExtra);
+                        Toast toast = Toast.makeText(context, text, durationExtra);
                         View toastView = toast.getView();
 
                         Drawable background = toastView.getBackground();
@@ -44,10 +43,9 @@ public class ToastAPI {
 
                         toast.setGravity(gravity, 0, 0);
                         toast.show();
+                        ResultReturner.noteDone(context);
                     }
                 });
-            }
-        });
     }
 
     protected static int getColor(JSONObject opts, String extra, int defaultColor) {

--- a/app/src/main/java/com/termux/api/TorchAPI.java
+++ b/app/src/main/java/com/termux/api/TorchAPI.java
@@ -13,13 +13,15 @@ import android.widget.Toast;
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.TermuxApiLogger;
 
+import org.json.JSONObject;
+
 public class TorchAPI {
     private static Camera legacyCamera;
 
 
     @TargetApi(Build.VERSION_CODES.M)
-    public static void onReceive(TermuxApiReceiver apiReceiver, final Context context, final Intent intent) {
-        boolean enabled = intent.getBooleanExtra("enabled", false);
+    public static void onReceive(final Context context, final JSONObject opts) {
+        boolean enabled = opts.optBoolean("enabled", false);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             toggleTorch(context, enabled);
@@ -27,7 +29,7 @@ public class TorchAPI {
             // use legacy api for pre-marshmallow
             legacyToggleTorch(enabled);
         }
-        ResultReturner.noteDone(apiReceiver, intent);
+        ResultReturner.noteDone(context);
     }
 
     @TargetApi(Build.VERSION_CODES.M)

--- a/app/src/main/java/com/termux/api/VibrateAPI.java
+++ b/app/src/main/java/com/termux/api/VibrateAPI.java
@@ -7,12 +7,14 @@ import android.os.Vibrator;
 
 import com.termux.api.util.ResultReturner;
 
+import org.json.JSONObject;
+
 public class VibrateAPI {
 
-    static void onReceive(TermuxApiReceiver apiReceiver, Context context, Intent intent) {
+    static void onReceive(Context context, JSONObject opts) {
         Vibrator vibrator = (Vibrator) context.getSystemService(Context.VIBRATOR_SERVICE);
-        int milliseconds = intent.getIntExtra("duration_ms", 1000);
-        boolean force = intent.getBooleanExtra("force", false);
+        int milliseconds = opts.optInt("duration_ms", 1000);
+        boolean force = opts.optBoolean("force", false);
 
         AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         if (am.getRingerMode() == AudioManager.RINGER_MODE_SILENT && !force) {
@@ -21,7 +23,7 @@ public class VibrateAPI {
             vibrator.vibrate(milliseconds);
         }
 
-        ResultReturner.noteDone(apiReceiver, intent);
+        ResultReturner.noteDone(context);
     }
 
 }

--- a/app/src/main/java/com/termux/api/WallpaperAPI.java
+++ b/app/src/main/java/com/termux/api/WallpaperAPI.java
@@ -12,6 +12,8 @@ import android.os.IBinder;
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.TermuxApiLogger;
 
+import org.json.JSONObject;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
@@ -26,9 +28,9 @@ import java.util.concurrent.TimeoutException;
 
 public class WallpaperAPI {
 
-    static void onReceive(final Context context, final Intent intent) {
+    static void onReceive(final Context context, JSONObject opts) {
         Intent wallpaperService = new Intent(context, WallpaperService.class);
-        wallpaperService.putExtras(intent.getExtras());
+        wallpaperService.putExtra("opts", opts.toString());
         context.startService(wallpaperService);
     }
 
@@ -49,7 +51,7 @@ public class WallpaperAPI {
             } else {
                 WallpaperResult result = new WallpaperResult();
                 result.error = "No args supplied for WallpaperAPI!";
-                postWallpaperResult(getApplicationContext(), intent, result);
+                postWallpaperResult(getApplicationContext(), result);
             }
 
             return Service.START_NOT_STICKY;
@@ -133,11 +135,11 @@ public class WallpaperAPI {
                     result.error = "Error setting wallpaper: " + e.getMessage();
                 }
             }
-            postWallpaperResult(context, intent, result);
+            postWallpaperResult(context, result);
         }
 
-        protected void postWallpaperResult(final Context context, final Intent intent, final WallpaperResult result) {
-            ResultReturner.returnData(context, intent, new ResultReturner.ResultWriter() {
+        protected void postWallpaperResult(final Context context, final WallpaperResult result) {
+            ResultReturner.returnData(context, new ResultReturner.ResultWriter() {
                 @Override
                 public void writeResult(PrintWriter out) {
                     out.append(result.message + "\n");

--- a/app/src/main/java/com/termux/api/WifiAPI.java
+++ b/app/src/main/java/com/termux/api/WifiAPI.java
@@ -14,12 +14,14 @@ import android.util.JsonWriter;
 
 import com.termux.api.util.ResultReturner;
 
+import org.json.JSONObject;
+
 import java.util.List;
 
 public class WifiAPI {
 
-    static void onReceiveWifiConnectionInfo(TermuxApiReceiver apiReceiver, final Context context, final Intent intent) {
-        ResultReturner.returnData(apiReceiver, intent, new ResultReturner.ResultJsonWriter() {
+    static void onReceiveWifiConnectionInfo(final Context context) {
+        ResultReturner.returnData(context, new ResultReturner.ResultJsonWriter() {
             @SuppressLint("HardwareIds")
             @Override
             public void writeJson(JsonWriter out) throws Exception {
@@ -51,8 +53,8 @@ public class WifiAPI {
         return lm.isProviderEnabled(LocationManager.GPS_PROVIDER);
     }
 
-    static void onReceiveWifiScanInfo(TermuxApiReceiver apiReceiver, final Context context, final Intent intent) {
-        ResultReturner.returnData(apiReceiver, intent, new ResultReturner.ResultJsonWriter() {
+    static void onReceiveWifiScanInfo(final Context context) {
+        ResultReturner.returnData(context, new ResultReturner.ResultJsonWriter() {
             @Override
             public void writeJson(JsonWriter out) throws Exception {
                 WifiManager manager = (WifiManager) context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
@@ -114,12 +116,12 @@ public class WifiAPI {
         });
     }
 
-    static void onReceiveWifiEnable(TermuxApiReceiver apiReceiver, final Context context, final Intent intent) {
-        ResultReturner.returnData(apiReceiver, intent, new ResultReturner.ResultJsonWriter() {
+    static void onReceiveWifiEnable(final Context context, final JSONObject opts) {
+        ResultReturner.returnData(context, new ResultReturner.ResultJsonWriter() {
             @Override
             public void writeJson(JsonWriter out) {
                 WifiManager manager = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
-                boolean state = intent.getBooleanExtra("enabled", false);
+                boolean state = opts.optBoolean("enabled", false);
                 manager.setWifiEnabled(state);
             }
         });

--- a/app/src/main/java/com/termux/api/util/TermuxApiPermissionActivity.java
+++ b/app/src/main/java/com/termux/api/util/TermuxApiPermissionActivity.java
@@ -23,7 +23,7 @@ public class TermuxApiPermissionActivity extends Activity {
      *
      * @return if all permissions were already granted
      */
-    public static boolean checkAndRequestPermissions(Context context, Intent intent, String... permissions) {
+    public static boolean checkAndRequestPermissions(Context context, String... permissions) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             final ArrayList<String> permissionsToRequest = new ArrayList<>();
             for (String permission : permissions) {
@@ -35,7 +35,7 @@ public class TermuxApiPermissionActivity extends Activity {
             if (permissionsToRequest.isEmpty()) {
                 return true;
             } else {
-                ResultReturner.returnData(context, intent, new ResultReturner.ResultJsonWriter() {
+                ResultReturner.returnData(context, new ResultReturner.ResultJsonWriter() {
                     @Override
                     public void writeJson(JsonWriter out) throws Exception {
                         String errorMessage = "Please grant the following permission"
@@ -49,7 +49,7 @@ public class TermuxApiPermissionActivity extends Activity {
                 Intent startIntent = new Intent(context, TermuxApiPermissionActivity.class)
                         .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                         .putStringArrayListExtra(TermuxApiPermissionActivity.PERMISSIONS_EXTRA, permissionsToRequest);
-                ResultReturner.copyIntentExtras(intent, startIntent);
+                //ResultReturner.copyIntentExtras(intent, startIntent);
                 context.startActivity(startIntent);
                 return false;
             }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha08'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sat Nov 17 13:35:29 GMT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip


### PR DESCRIPTION
This PR replaces the Broadcast Reciever with a service listening on a socket resulting in a much faster response (miliseconds instead of seconds).
JSON is sent over the `termux-input` socket and the results get returned on `termux-output`

This is more of a proof of concept for the time being a lot is not working/not yet implemented, I'm open to any feedback on how to improve this.

A test suite would be nice for testing all the APIs, any suggestions for how to implement that would be nice.

# Tested APIs
- [x] WifiAPI.java
- [x] AudioAPI.java
- [x] TorchAPI.java
- [x] ToastAPI.java
- [x] BatteryStatusAPI.java
- [x] CallLogAPI.java
- [x] CameraInfoAPI.java
- [x] VolumeAPI.java
- [x] BrightnessAPI.java - 
- [x] ContactListAPI.java    
- [x] NotificationListAPI.java
- [x] NotificationAPI.java      
- [x] SmsInboxAPI.java
- [x] VibrateAPI.java
- [ ] FingerprintAPI.java 
- [ ] PhotoAPI.java
- [ ] TextToSpeechAPI.java
- [ ] InfraredAPI.java - Can't test (no IR on my phone)
- [ ] SensorAPI.java
- [ ] KeystoreAPI.java
- [ ] ShareAPI.java
- [ ] LocationAPI.java
- [ ] MediaPlayerAPI.java
- [ ] SmsSendAPI.java
- [ ] MediaScannerAPI.java
- [ ] SpeechToTextAPI.java
- [ ] WallpaperAPI.java
- [ ] ClipboardAPI.java - Crashes
- [ ] MicRecorderAPI.java
- [ ] StorageGetAPI.java      
- [ ] TelephonyAPI.java
- [ ] DialogActivity.java    
- [ ] DownloadAPI.java

# Bugs/Issues:
~~Out of memory exception happens with dialogs, current work around is android:largeHeap="true" but this is obviosuly not a permanent fix.~~ fixed

# Usage Examples: 
This PR Requires the modified termux-api binary from here https://github.com/Epictek/termux-api-package/blob/master/termux-api.c PR incoming for that soon once I figure out how to handle rewriting all the scripts.
```
# Start the service (This will be implemented in to termux-api.c later)
am broadcast --user 0 -n com.termux.api/.TermuxApiReceiver
# Call logs
echo "{'api_method':'CallLog'}" | ./termux-api
# Date input
echo "{'api_method':'Dialog','input_method':'date'}" | ./termux-api
```