### PR TITLE
Battery Current in μA

### DIFF
--- a/app/src/main/java/com/termux/api/BatteryStatusAPI.java
+++ b/app/src/main/java/com/termux/api/BatteryStatusAPI.java
@@ -97,7 +97,7 @@ public class BatteryStatusAPI {
                         batteryStatusString = "UNKNOWN";
                 }
 
-                double batteryCurrent = batteryStatus.getIntExtra(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW, -1);
+                int batteryCurrent = batteryStatus.getLongProperty(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW);
 
                 out.beginObject();
                 out.name("health").value(batteryHealth);

--- a/app/src/main/java/com/termux/api/BatteryStatusAPI.java
+++ b/app/src/main/java/com/termux/api/BatteryStatusAPI.java
@@ -97,7 +97,7 @@ public class BatteryStatusAPI {
                         batteryStatusString = "UNKNOWN";
                 }
 
-                int batteryCurrent = batteryStatus.getLongProperty(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW);
+                long batteryCurrent = batteryStatus.getLongProperty(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW);
 
                 out.beginObject();
                 out.name("health").value(batteryHealth);

--- a/app/src/main/java/com/termux/api/BatteryStatusAPI.java
+++ b/app/src/main/java/com/termux/api/BatteryStatusAPI.java
@@ -97,12 +97,15 @@ public class BatteryStatusAPI {
                         batteryStatusString = "UNKNOWN";
                 }
 
+                double batteryCurrent = batteryStatus.getIntExtra(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW, -1);
+
                 out.beginObject();
                 out.name("health").value(batteryHealth);
                 out.name("percentage").value(batteryPercentage);
                 out.name("plugged").value(batteryPlugged);
                 out.name("status").value(batteryStatusString);
                 out.name("temperature").value(batteryTemperature);
+                out.name("current").value(batteryCurrent);
                 out.endObject();
             }
         });


### PR DESCRIPTION
Prints current battery current in microamperes.
Useful for charging current detection.