### PR TITLE
Fix for issue #295

### DIFF
--- a/app/src/main/java/com/termux/api/SensorAPI.java
+++ b/app/src/main/java/com/termux/api/SensorAPI.java
@@ -277,12 +277,24 @@ public class SensorAPI {
                 for (String sensorName : requestedSensors) {
                     // ignore case
                     sensorName = sensorName.toUpperCase();
-
+                    boolean sensorMatch = false;
+                    
                     for (Sensor sensor : availableSensors) {
-                        if (sensor.getName().toUpperCase().contains(sensorName)) {
+                        if (sensor.getName().toUpperCase().equals(sensorName)) {
                             sensorManager.registerListener(sensorEventListener, sensor, SensorManager.SENSOR_DELAY_UI);
                             sensorsToListenTo.add(sensor);
+                            sensorMatch = true;
                             break;
+                        }
+                    }
+                    
+                    if (sensorMatch = false) { 
+                        for (Sensor sensor : availableSensors) {
+                            if (sensor.getName().toUpperCase().contains(sensorName)) {
+                                sensorManager.registerListener(sensorEventListener, sensor, SensorManager.SENSOR_DELAY_UI);
+                                sensorsToListenTo.add(sensor);
+                                break;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Changed sensor pattern matching to first look for a completely matching sensor before looking for a partial match. Fixes issue #295 where sensors can be inaccessible.

I know it's gross but a else-if wouldn't work due to still breaking out due to partial match before checking all sensors for a complete match. I would love to find out how to do this without a flag variable and duplicating so much code. 