### PR TITLE
Dialog: add ability to have commas as characters within items

### DIFF
--- a/app/src/main/java/com/termux/api/DialogActivity.java
+++ b/app/src/main/java/com/termux/api/DialogActivity.java
@@ -96,13 +96,13 @@ public class DialogActivity extends AppCompatActivity {
         String[] items = new String[] { };
 
         if (intent != null && intent.hasExtra("input_values")) {
-            String[] temp = intent.getStringExtra("input_values").split(",");
+            String[] temp = intent.getStringExtra("input_values").split("(?<!\\\\),");
             items = new String[temp.length];
 
             // remove possible whitespace from strings in temp array
             for (int j = 0; j < temp.length; ++j) {
                 String s = temp[j];
-                items[j] = s.trim();
+                items[j] = s.trim().replace("\\,", ",");
             }
         }
         return items;


### PR DESCRIPTION
I propose that the ability to have escaped commas in items.

This would be useful in certain situations, such as when dealing with titles (some titles contain commas), and this edit would allow the user to escape commas in comma-separated lists, by passing: `-v 'item 1, item 1\, part 2'` or `"item 1, item 1\\, part 2"` as an argument to termux-dialog.