### PR TITLE
Update Permissions to allow installing/uninstalling of apps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,10 @@
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <!-- permissions to install/uninstall apps --> 
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" /> 
+    <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" /> 
+
     <!-- Some of the used permissions imply uses-feature, so we need to make it optional.
          See http://developer.android.com/guide/topics/manifest/uses-feature-element.html#permissions -->
     <uses-feature android:name="android.hardware.camera" android:required="false" />


### PR DESCRIPTION
This commit should be used along with: https://github.com/termux/termux-api-package/pull/94 to provide the ability to install/uninstall apps.

Tested on Galaxy J701F running android 8.1.0.

This should also close #324