### PR TITLE
Add Dark Theme

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -17,9 +17,11 @@
         <item name="windowNoTitle">true</item>
     </style>
 
+    <style name="DialogTheme.Dark" parent="Theme.AppCompat.Dialog.Alert">
+        <item name="windowNoTitle">true</item>
+    </style>
 
     <style name="TransparentTheme" parent="@style/Theme.AppCompat.Light">
-
         <item name="android:background">@android:color/transparent</item>
         <item name="background">@android:color/transparent</item>
 


### PR DESCRIPTION
#297 (doesn't necessarily close)

Added dark theme for dialogs is use-black-ui is true. Not quite black as I couldn't figure that out, but the Termux dialogs (such as when you are setting session name) don't seem to be either, so I think this is probably OK. 