### PR TITLE
Replace getDeviceId with non-deprecated methods

### DIFF
--- a/app/src/main/java/com/termux/api/TelephonyAPI.java
+++ b/app/src/main/java/com/termux/api/TelephonyAPI.java
@@ -167,13 +167,15 @@ public class TelephonyAPI {
                     }
                     out.name("data_state").value(dataStateString);
 
-                    out.name("device_id").value(manager.getDeviceId());
+                    int phoneType = manager.getPhoneType();
+
+                    String device_id = phoneType == TelephonyManager.PHONE_TYPE_GSM ? manager.getImei() : manager.getMeid();
+                    out.name("device_id").value(device_id);
                     out.name("device_software_version").value(manager.getDeviceSoftwareVersion());
 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                         out.name("phone_count").value(manager.getPhoneCount());
                     }
-                    int phoneType = manager.getPhoneType();
                     String phoneTypeString;
                     switch (phoneType) {
                         case TelephonyManager.PHONE_TYPE_CDMA:


### PR DESCRIPTION
Closes #279.

Tested on a GSM device, should work with CDMA as per https://developer.android.com/reference/android/telephony/TelephonyManager#getDeviceId().

Uncertain of whether this'll work with Sip devices since an alternative for that doesn't seem to be mentioned in https://developer.android.com/reference/android/telephony/TelephonyManager#getDeviceId() - someone should test that (don't have such a device) 