### PR TITLE
Exit with remaining text if user touches outside dialog

### DIFF
--- a/app/src/main/java/com/termux/api/DialogActivity.java
+++ b/app/src/main/java/com/termux/api/DialogActivity.java
@@ -1017,7 +1017,9 @@ public class DialogActivity extends AppCompatActivity {
         }
 
         void onDismissed() {
-            postCanceledResult();
+            InputResult result = new InputResult();
+            result.text = getResult();
+            result.code = Dialog.BUTTON_NEGATIVE;                           resultListener.onResult(result);
         }
 
         /**


### PR DESCRIPTION
Closes #275. 

Chose to exit with text instead of keeping the dialog, because https://github.com/termux/termux-api/blob/67954de3638b45abed48c40b4df907ebd940ee32/app/src/main/java/com/termux/api/DialogActivity.java#L989 indicates that that's intended behaviour. 