### PR TITLE
ISSUE-368 - ensure full list of scheduled jobs is returned

### DIFF
--- a/app/src/main/java/com/termux/api/JobSchedulerAPI.java
+++ b/app/src/main/java/com/termux/api/JobSchedulerAPI.java
@@ -180,9 +180,12 @@ public class JobSchedulerAPI {
             ResultReturner.returnData(apiReceiver, intent, out -> out.println("No pending jobs"));
             return;
         }
+
+        StringBuilder stringBuilder = new StringBuilder();
         for (JobInfo job : jobs) {
-            ResultReturner.returnData(apiReceiver, intent, out -> out.println(String.format(Locale.ENGLISH, "Pending %s", formatJobInfo(job))));
+            stringBuilder.append(String.format(Locale.ENGLISH, "Pending %s\n", formatJobInfo(job)));
         }
+        ResultReturner.returnData(apiReceiver, intent, out -> out.println(stringBuilder.toString()));
     }
 
     @RequiresApi(api = Build.VERSION_CODES.N)


### PR DESCRIPTION
My attempt to resolve the bug described in issue: https://github.com/termux/termux-api/issues/368

in that bug, only a single scheduled job is returned - even if there are multiple scheduled jobs defined.

This change simply builds up an appended string of all scheduled jobs, and then returns this in a single call to `ResultReturner.returnData`
