### PR TITLE
Add inbox content URI

### DIFF
--- a/app/src/main/java/com/termux/api/SmsInboxAPI.java
+++ b/app/src/main/java/com/termux/api/SmsInboxAPI.java
@@ -177,6 +177,7 @@ public class SmsInboxAPI {
             case TextBasedSmsColumns.MESSAGE_TYPE_OUTBOX:
                 return Sms.Outbox.CONTENT_URI;
             case TextBasedSmsColumns.MESSAGE_TYPE_INBOX:
+                return Sms.Inbox.CONTENT_URI;
             case TextBasedSmsColumns.MESSAGE_TYPE_ALL:
             default:
                 return Sms.CONTENT_URI;


### PR DESCRIPTION
This commit adds the inbox content URI so termux-sms-list can filter type by inbox, rather than default to all.