### PR TITLE
Allow connection via a UNIX socket as a faster alternative

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -106,6 +106,11 @@
         <service
             android:name=".SchedulerJobService"
             android:permission="android.permission.BIND_JOB_SERVICE" />
+        <service
+            android:name=".KeepAliveService"
+            android:description="@string/keep_alive_service"
+            android:enabled="true"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/termux/api/App.java
+++ b/app/src/main/java/com/termux/api/App.java
@@ -27,7 +27,7 @@ public class App extends Application
     private static final Pattern EXTRA_INT_LIST = Pattern.compile("--eia +([^ ]+) +(-?[0-9]+(?:,-?[0-9]+)*)");
     private static final Pattern EXTRA_LONG_LIST = Pattern.compile("--ela +([^ ]+) +(-?[0-9]+(?:,-?[0-9]+)*)");
     private static final Pattern EXTRA_UNSUPPORTED = Pattern.compile("--e[^izs ] +[^ ]+ +[^ ]+");
-
+    private static final Pattern ACTION = Pattern.compile("-a *([^ ]+)");
 
     @Override
     public void onCreate() {
@@ -49,6 +49,7 @@ public class App extends Application
                             in.readFully(b);
                             String cmdline = new String(b, StandardCharsets.UTF_8);
 
+                            Intent intent = new Intent(getApplicationContext(), TermuxApiReceiver.class);
                             //System.out.println(cmdline.replaceAll("--es socket_input \".*?\"","").replaceAll("--es socket_output \".*?\"",""));
                             HashMap<String, String> stringExtras = new HashMap<>();
                             HashMap<String, String[]> stringArrayExtras = new HashMap<>();
@@ -151,6 +152,12 @@ public class App extends Application
                             }
                             cmdline = m.replaceAll("");
 
+                            m = ACTION.matcher(cmdline);
+                            while (m.find()) {
+                                intent.setAction(m.group(1));
+                            }
+                            cmdline = m.replaceAll("");
+
                             m = EXTRA_UNSUPPORTED.matcher(cmdline);
                             if (m.find()) {
                                 String msg = "Unsupported argument type: " + m.group(0) + "\n";
@@ -174,30 +181,29 @@ public class App extends Application
                                 continue;
                             }
 
-                            // construct the intent with the extras
-                            Intent i = new Intent(getApplicationContext(), TermuxApiReceiver.class);
+                            // set the intent extras
                             for (Map.Entry<String, String> e : stringExtras.entrySet()) {
-                                i.putExtra(e.getKey(), e.getValue());
+                                intent.putExtra(e.getKey(), e.getValue());
                             }
                             for (Map.Entry<String, String[]> e : stringArrayExtras.entrySet()) {
-                                i.putExtra(e.getKey(), e.getValue());
+                                intent.putExtra(e.getKey(), e.getValue());
                             }
                             for (Map.Entry<String, Integer> e : intExtras.entrySet()) {
-                                i.putExtra(e.getKey(), e.getValue());
+                                intent.putExtra(e.getKey(), e.getValue());
                             }
                             for (Map.Entry<String, Boolean> e : booleanExtras.entrySet()) {
-                                i.putExtra(e.getKey(), e.getValue());
+                                intent.putExtra(e.getKey(), e.getValue());
                             }
                             for (Map.Entry<String, Float> e : floatExtras.entrySet()) {
-                                i.putExtra(e.getKey(), e.getValue());
+                                intent.putExtra(e.getKey(), e.getValue());
                             }
                             for (Map.Entry<String, int[]> e : intArrayExtras.entrySet()) {
-                                i.putExtra(e.getKey(), e.getValue());
+                                intent.putExtra(e.getKey(), e.getValue());
                             }
                             for (Map.Entry<String, long[]> e : longArrayExtras.entrySet()) {
-                                i.putExtra(e.getKey(), e.getValue());
+                                intent.putExtra(e.getKey(), e.getValue());
                             }
-                            getApplicationContext().sendOrderedBroadcast(i, null);
+                            getApplicationContext().sendOrderedBroadcast(intent, null);
                             // send a null byte as a sign that the arguments have been successfully received, parsed and the broadcast receiver is called
                             con.getOutputStream().write(0);
                             con.getOutputStream().flush();

--- a/app/src/main/java/com/termux/api/App.java
+++ b/app/src/main/java/com/termux/api/App.java
@@ -1,0 +1,217 @@
+package com.termux.api;
+
+import android.app.Application;
+import android.content.Intent;
+import android.net.LocalServerSocket;
+import android.net.LocalSocket;
+
+import com.termux.api.util.TermuxApiLogger;
+
+import java.io.BufferedWriter;
+import java.io.DataInputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class App extends Application
+{
+    public static final String LISTEN_ADDRESS = "com.termux.api://listen";
+    private static final Pattern EXTRA_STRING = Pattern.compile("(-e|--es|--esa) +([^ ]+) +\"(.*?)(?<!\\\\)\"", Pattern.DOTALL);
+    private static final Pattern EXTRA_BOOLEAN = Pattern.compile("--ez +([^ ]+) +([^ ]+)");
+    private static final Pattern EXTRA_INT = Pattern.compile("--ei +([^ ]+) +(-?[0-9]+)");
+    private static final Pattern EXTRA_FLOAT = Pattern.compile("--ef +([^ ]+) +(-?[0-9]+(?:\\.[0-9]+))");
+    private static final Pattern EXTRA_INT_LIST = Pattern.compile("--eia +([^ ]+) +(-?[0-9]+(?:,-?[0-9]+)*)");
+    private static final Pattern EXTRA_LONG_LIST = Pattern.compile("--ela +([^ ]+) +(-?[0-9]+(?:,-?[0-9]+)*)");
+    private static final Pattern EXTRA_UNSUPPORTED = Pattern.compile("--e[^izs ] +[^ ]+ +[^ ]+");
+
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        new Thread(() -> {
+            try (LocalServerSocket listen = new LocalServerSocket(LISTEN_ADDRESS)) {
+                while (true) {
+                    try (LocalSocket con = listen.accept();
+                         DataInputStream in = new DataInputStream(con.getInputStream());
+                         BufferedWriter out = new BufferedWriter(new OutputStreamWriter(con.getOutputStream()))) {
+                        // only accept connections from Termux programs
+                        if (con.getPeerCredentials().getUid() != getApplicationInfo().uid) {
+                            continue;
+                        }
+                        try {
+                            //System.out.println("connection");
+                            int length = in.readUnsignedShort();
+                            byte[] b = new byte[length];
+                            in.readFully(b);
+                            String cmdline = new String(b, StandardCharsets.UTF_8);
+
+                            //System.out.println(cmdline.replaceAll("--es socket_input \".*?\"","").replaceAll("--es socket_output \".*?\"",""));
+                            HashMap<String, String> stringExtras = new HashMap<>();
+                            HashMap<String, String[]> stringArrayExtras = new HashMap<>();
+                            HashMap<String, Boolean> booleanExtras = new HashMap<>();
+                            HashMap<String, Integer> intExtras = new HashMap<>();
+                            HashMap<String, Float> floatExtras = new HashMap<>();
+                            HashMap<String, int[]> intArrayExtras = new HashMap<>();
+                            HashMap<String, long[]> longArrayExtras = new HashMap<>();
+                            boolean err = false;
+
+                            // extract and remove the string extras first, so another argument embedded in a string isn't counted as an argument
+                            Matcher m = EXTRA_STRING.matcher(cmdline);
+                            while (m.find()) {
+                                String option = m.group(1);
+                                if ("-e".equals(option) || "--es".equals(option)) {
+                                    // unescape "
+                                    stringExtras.put(m.group(2), Objects.requireNonNull(m.group(3)).replaceAll("\\\\\"","\""));
+                                } else {
+                                    // split the list
+                                    String[] list = Objects.requireNonNull(m.group(3)).split("(?<!\\\\),");
+                                    for (int i = 0; i<list.length; i++) {
+                                        /// unescape the ","
+                                        list[i] = list[i].replaceFirst("\\\\,", ",");
+                                    }
+                                    stringArrayExtras.put(m.group(2), list);
+                                }
+
+                            }
+                            cmdline = m.replaceAll("");
+
+                            m = EXTRA_BOOLEAN.matcher(cmdline);
+                            while (m.find()) {
+                                booleanExtras.put(m.group(1), Boolean.parseBoolean(m.group(2)));
+                            }
+                            cmdline = m.replaceAll("");
+
+                            m = EXTRA_INT.matcher(cmdline);
+                            while (m.find()) {
+                                try {
+                                    intExtras.put(m.group(1), Integer.parseInt(Objects.requireNonNull(m.group(2))));
+                                } catch (NumberFormatException e) {
+                                    String msg = "Invalid integer extra: " + m.group(0) + "\n";
+                                    TermuxApiLogger.info(msg);
+                                    out.write(msg);
+                                    err = true;
+                                    break;
+                                }
+                            }
+                            cmdline = m.replaceAll("");
+
+                            m = EXTRA_FLOAT.matcher(cmdline);
+                            while (m.find()) {
+                                try {
+                                    floatExtras.put(m.group(1), Float.parseFloat(Objects.requireNonNull(m.group(2))));
+                                } catch (NumberFormatException e) {
+                                    String msg = "Invalid float extra: " + m.group(0) + "\n";
+                                    TermuxApiLogger.info(msg);
+                                    out.write(msg);
+                                    err = true;
+                                    break;
+                                }
+                            }
+                            cmdline = m.replaceAll("");
+
+                            m = EXTRA_INT_LIST.matcher(cmdline);
+                            while (m.find()) {
+                                try {
+                                    String[] parts = Objects.requireNonNull(m.group(2)).split(",");
+                                    int[] ints = new int[parts.length];
+                                    for (int i = 0; i<parts.length; i++) {
+                                        ints[i] = Integer.parseInt(parts[i]);
+                                    }
+                                    intArrayExtras.put(m.group(1), ints);
+                                } catch (NumberFormatException e) {
+                                    String msg = "Invalid int array extra: " + m.group(0) + "\n";
+                                    TermuxApiLogger.info(msg);
+                                    out.write(msg);
+                                    err = true;
+                                    break;
+                                }
+                            }
+                            cmdline = m.replaceAll("");
+
+                            m = EXTRA_LONG_LIST.matcher(cmdline);
+                            while (m.find()) {
+                                try {
+                                    String[] parts = Objects.requireNonNull(m.group(2)).split(",");
+                                    long[] longs = new long[parts.length];
+                                    for (int i = 0; i<parts.length; i++) {
+                                        longs[i] = Long.parseLong(parts[i]);
+                                    }
+                                    longArrayExtras.put(m.group(1), longs);
+                                } catch (NumberFormatException e) {
+                                    String msg = "Invalid long array extra: " + m.group(0) + "\n";
+                                    TermuxApiLogger.info(msg);
+                                    out.write(msg);
+                                    err = true;
+                                    break;
+                                }
+                            }
+                            cmdline = m.replaceAll("");
+
+                            m = EXTRA_UNSUPPORTED.matcher(cmdline);
+                            if (m.find()) {
+                                String msg = "Unsupported argument type: " + m.group(0) + "\n";
+                                TermuxApiLogger.info(msg);
+                                out.write(msg);
+                                err = true;
+                            }
+                            cmdline = m.replaceAll("");
+
+                            // check if there are any non-whitespace characters left after parsing all the options
+                            cmdline = cmdline.replaceAll("\\s", "");
+                            if (! "".equals(cmdline)) {
+                                String msg = "Unsupported options: " + cmdline + "\n";
+                                TermuxApiLogger.info(msg);
+                                out.write(msg);
+                                err = true;
+                            }
+
+                            if (err) {
+                                out.flush();
+                                continue;
+                            }
+
+                            // construct the intent with the extras
+                            Intent i = new Intent(getApplicationContext(), TermuxApiReceiver.class);
+                            for (Map.Entry<String, String> e : stringExtras.entrySet()) {
+                                i.putExtra(e.getKey(), e.getValue());
+                            }
+                            for (Map.Entry<String, String[]> e : stringArrayExtras.entrySet()) {
+                                i.putExtra(e.getKey(), e.getValue());
+                            }
+                            for (Map.Entry<String, Integer> e : intExtras.entrySet()) {
+                                i.putExtra(e.getKey(), e.getValue());
+                            }
+                            for (Map.Entry<String, Boolean> e : booleanExtras.entrySet()) {
+                                i.putExtra(e.getKey(), e.getValue());
+                            }
+                            for (Map.Entry<String, Float> e : floatExtras.entrySet()) {
+                                i.putExtra(e.getKey(), e.getValue());
+                            }
+                            for (Map.Entry<String, int[]> e : intArrayExtras.entrySet()) {
+                                i.putExtra(e.getKey(), e.getValue());
+                            }
+                            for (Map.Entry<String, long[]> e : longArrayExtras.entrySet()) {
+                                i.putExtra(e.getKey(), e.getValue());
+                            }
+                            getApplicationContext().sendOrderedBroadcast(i, null);
+                            // send a null byte as a sign that the arguments have been successfully received, parsed and the broadcast receiver is called
+                            con.getOutputStream().write(0);
+                            con.getOutputStream().flush();
+                        } catch (Exception e) {
+                            TermuxApiLogger.error("Error parsing arguments", e);
+                            out.write("Exception in the plugin\n");
+                            out.flush();
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                TermuxApiLogger.error("Error listening for connections", e);
+            }
+        }).start();
+    }
+
+}

--- a/app/src/main/java/com/termux/api/KeepAliveService.java
+++ b/app/src/main/java/com/termux/api/KeepAliveService.java
@@ -1,0 +1,21 @@
+package com.termux.api;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+
+import androidx.annotation.Nullable;
+
+public class KeepAliveService extends Service
+{
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        return Service.START_STICKY;
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,6 @@
     <string name="app_name">&TERMUX_API_APP_NAME;</string>
     <string name="share_file_chooser_title">Share with</string>
     <string name="grant_permission">Grant permission</string>
-
+    <string name="keep_alive_service">This service keeps Termux:API running in the background for faster startup of termux-* commands.</string>
     <string name="permission_description">This app needs the following permission(s):\n</string>
 </resources>


### PR DESCRIPTION
This creates a UNIX socket at application startup. You can send the extra arguments that would normally be passed to am over the socket, so there is no need to create a whole DalvikVM just to connect to the plugin every time.  
  
The arguments get parsed with regex, string arguments have to be surrounded with double quotes every time. String argument arrays also have to be surrounded by double quotes. Other than that the options are parsed just like for am. I currently have implemented all options needed for the termux-api-package (I `grep`'d all possible extras from the scripts). If there is an error, the message gets send back over the socket. If the constructed Intent was successfully send to the receiver, a single null byte is send back to signify success. With that it even works when the process is terminated by the system, because no response means the process got killed.   
There is also a dummy background service that can be started with `am` to keep the process running, so the socket doesn't get closed. 
  
I tested it with:  
- termux-api-start
- termux-api-stop
- termux-audio-info
- termux-battery-status
- termux-brightness
- termux-call-log
- termux-camera-info
- termux-camera-photo
- termux-clipboard-get
- termux-clipboard-set
- termux-contact-list
- termux-dialog

so far and it works well. On my phone the performance was ~10x better.  
This should fix #63 good enough.  

  
[There is a corresponding PR for termux-api-package](https://github.com/termux/termux-api-package/pull/147).