### PR TITLE
Notification channel support

### DIFF
--- a/app/src/main/java/com/termux/api/TermuxApiReceiver.java
+++ b/app/src/main/java/com/termux/api/TermuxApiReceiver.java
@@ -5,8 +5,6 @@ import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import android.nfc.NfcAdapter;
-import android.os.Build;
 import android.provider.Settings;
 import android.widget.Toast;
 
@@ -130,6 +128,9 @@ public class TermuxApiReceiver extends BroadcastReceiver {
                 break;
             case "Notification":
                 NotificationAPI.onReceiveShowNotification(this, context, intent);
+                break;
+            case "NotificationChannel":
+                NotificationAPI.onReceiveChannel(this, context, intent);
                 break;
             case "NotificationRemove":
                 NotificationAPI.onReceiveRemoveNotification(this, context, intent);


### PR DESCRIPTION
I added an interface to create and delete notification channels on Android 8.0 and higher and added an option to specify the channel for posting a notification.  
  
[The corresponding changes to termux-api-package are here.](https://github.com/tareksander/termux-api-package/tree/notification-channels)  

closes #419.