### PR TITLE
Allow passthrough of extras to Android API for SpeechToText

### DIFF
--- a/app/src/main/java/com/termux/api/apis/SpeechToTextAPI.java
+++ b/app/src/main/java/com/termux/api/apis/SpeechToTextAPI.java
@@ -19,6 +19,8 @@ import com.termux.shared.logger.Logger;
 
 import java.io.PrintWriter;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingQueue;
 
 public class SpeechToTextAPI {
@@ -38,6 +40,8 @@ public class SpeechToTextAPI {
         }
 
         protected SpeechRecognizer mSpeechRecognizer;
+	final CountDownLatch latch = new CountDownLatch(1);
+	final Intent recognizerIntent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
         final LinkedBlockingQueue<String> queueu = new LinkedBlockingQueue<>();
 
         private static final String LOG_TAG = "SpeechToTextService";
@@ -47,6 +51,7 @@ public class SpeechToTextAPI {
             Logger.logDebug(LOG_TAG, "onCreate");
 
             super.onCreate();
+
             final Context context = this;
 
             mSpeechRecognizer = SpeechRecognizer.createSpeechRecognizer(this);
@@ -62,6 +67,10 @@ public class SpeechToTextAPI {
                     List<String> recognitions = results.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION);
                     Logger.logError(LOG_TAG, "RecognitionListener#onResults(" + recognitions + ")");
                     queueu.addAll(recognitions);
+		    // On full mode, stop only when recognition is achieved
+		    if (!recognizerIntent.getBooleanExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)) {
+			    queueu.add(STOP_ELEMENT);
+		    }
                 }
 
                 @Override
@@ -108,7 +117,11 @@ public class SpeechToTextAPI {
                 @Override
                 public void onEndOfSpeech() {
                     Logger.logError(LOG_TAG, "RecognitionListener#onEndOfSpeech()");
-                    queueu.add(STOP_ELEMENT);
+
+		    // On partial mode, stop recognition when speech ends
+		    if (recognizerIntent.getBooleanExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)) {
+			    queueu.add(STOP_ELEMENT);
+		    }
                 }
 
                 @Override
@@ -141,13 +154,12 @@ public class SpeechToTextAPI {
                         .create().show();
             }
 
-            Intent recognizerIntent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
-            recognizerIntent.putExtra(RecognizerIntent.EXTRA_PROMPT, "Enter shell command");
-            recognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
-            recognizerIntent.putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 10);
-            recognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, "en-US");
-            recognizerIntent.putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true);
+	    try {
+		latch.await(1, TimeUnit.SECONDS);
+	    } catch (InterruptedException e) {
+	    }
             mSpeechRecognizer.startListening(recognizerIntent);
+
         }
 
         @Override
@@ -162,9 +174,20 @@ public class SpeechToTextAPI {
         protected void onHandleIntent(final Intent intent) {
             Logger.logDebug(LOG_TAG, "onHandleIntent:\n" + IntentUtils.getIntentString(intent));
 
+
+            recognizerIntent.putExtra(RecognizerIntent.EXTRA_PROMPT, "Enter shell command");
+            recognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
+            recognizerIntent.putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 10);
+	    recognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, "en-US");
+            recognizerIntent.putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true);
+
+	    recognizerIntent.putExtras(intent.getExtras());
+	    latch.countDown();
+
             ResultReturner.returnData(this, intent, new ResultReturner.WithInput() {
                 @Override
                 public void writeResult(PrintWriter out) throws Exception {
+                    Logger.logError(LOG_TAG, "Start listening");
                     while (true) {
                         String s = queueu.take();
                         if (s == STOP_ELEMENT) {


### PR DESCRIPTION
Enable more customization of the SpeechToText behavioiur:

> $PREFIX/libexec/termux-api SpeechToText --es android.speech.extra.LANGUAGE fr-FR --ei android.speech.extra.MAX_RESULTS 1 --ez android.speech.extra.PARTIAL_RESULTS false

Additionally, the original behaviour where the speech recognition ends on speech end is retained only when "android.speech.extra.PARTIAL_RESULTS" is set to true, otherwise the behaviour is to wait for the final recognition results.