### PR TITLE
Allow setting both wallpapers at once [1/2]

### DIFF
--- a/app/src/main/java/com/termux/api/apis/WallpaperAPI.java
+++ b/app/src/main/java/com/termux/api/apis/WallpaperAPI.java
@@ -122,8 +122,11 @@ public class WallpaperAPI {
 
             if (result.wallpaper != null) {
                 try {
-                    int flag = intent.hasExtra("lockscreen") ? WallpaperManager.FLAG_LOCK : WallpaperManager.FLAG_SYSTEM;
-                    wallpaperManager.setBitmap(result.wallpaper, null, true, flag);
+                    int which = WallpaperManager.FLAG_SYSTEM | WallpaperManager.FLAG_LOCK;
+                    if (intent.hasExtra("lockscreen")) {
+                        which = intent.getBooleanExtra("lockscreen", false) ? WallpaperManager.FLAG_LOCK : WallpaperManager.FLAG_SYSTEM;
+                    }
+                    wallpaperManager.setBitmap(result.wallpaper, null, true, which);
                     result.message = "Wallpaper set successfully!";
                 } catch (IOException e) {
                     result.error = "Error setting wallpaper: " + e.getMessage();


### PR DESCRIPTION
The old implementation allowed only to set one of the two backgrounds at one time, but not both at once.

The Java part of this is mostly backwards compatible with the old `termux-wallpaper` script, except it is no longer possible to set just the homescreen wallpaper.