### PR TITLE
Fixed: Text not visible when in dark mode for bottom sheet dialog

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -15,10 +15,12 @@
 
     <style name="DialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="windowNoTitle">true</item>
+        <item name="bottomSheetDialogTheme">@style/Theme.Design.Light.BottomSheetDialog</item>
     </style>
 
     <style name="DialogTheme.Dark" parent="Theme.AppCompat.Dialog.Alert">
         <item name="windowNoTitle">true</item>
+        <item name="bottomSheetDialogTheme">@style/Theme.Design.BottomSheetDialog</item>
     </style>
 
     <style name="TransparentTheme" parent="@style/Theme.AppCompat.Light">


### PR DESCRIPTION
Fixes issue #505 

<img width="558" alt="" src="https://user-images.githubusercontent.com/6166095/178125270-58dfbc0b-d3f8-4139-9c35-1de957ccc5f3.png">

