### PR TITLE
Handle unexpected socket client disconnects

### DIFF
--- a/app/src/main/java/com/termux/api/SocketListener.java
+++ b/app/src/main/java/com/termux/api/SocketListener.java
@@ -223,6 +223,9 @@ public class SocketListener {
                                 out.flush();
                             }
                         }
+                        catch (java.io.IOException e) {
+                            Logger.logStackTraceWithMessage(LOG_TAG, "Connection error", e);
+                        }
                     }
                 }
                 catch (Exception e) {


### PR DESCRIPTION
Add a catch to the `try (LocalSocket con = listen.accept(); ...) {` statement in order to handle unexpected client disconnects.

A simple test case is:
```
python -c "import socket
s=socket.socket(socket.AF_UNIX)
s.connect(b'\0com.termux.api://listen')
s.close()"
```

Before, this crashed the service, causing connection refused errors until Termux:API was force-stopped via app info