### PR TITLE
NotificationAPI: Replace `sound` option with `silent`

### DIFF
--- a/app/src/main/java/com/termux/api/apis/NotificationAPI.java
+++ b/app/src/main/java/com/termux/api/apis/NotificationAPI.java
@@ -174,7 +174,7 @@ public class NotificationAPI {
         int ledOffMs = intent.getIntExtra("led-off", 800);
 
         long[] vibratePattern = intent.getLongArrayExtra("vibrate");
-        boolean useSound = intent.getBooleanExtra("sound", false);
+        boolean silent = intent.getBooleanExtra("silent", false);
         boolean ongoing = intent.getBooleanExtra("ongoing", false);
         boolean alertOnce = intent.getBooleanExtra("alert-once", false);
 
@@ -275,7 +275,7 @@ public class NotificationAPI {
             notification.setVibrate(vibrateArg);
         }
 
-        if (useSound) notification.setSound(Settings.System.DEFAULT_NOTIFICATION_URI);
+        if (silent) notification.setSilent(true);
 
         notification.setAutoCancel(true);
 


### PR DESCRIPTION
The sound option is being ignored in favor of channel settings. Instead, add a silent option to be able to create notifications without playing any sound. Currently, this can only be done by creating a channel and manually disabling its notification sound.

Should help with fixing #319