### PR TITLE
KeyStoreAPI Upgrade (Encrypt/Decrypt + more)

### DIFF
--- a/app/src/main/java/com/termux/api/TermuxApiReceiver.java
+++ b/app/src/main/java/com/termux/api/TermuxApiReceiver.java
@@ -146,7 +146,7 @@ public class TermuxApiReceiver extends BroadcastReceiver {
                 JobSchedulerAPI.onReceive(this, context, intent);
                 break;
             case "Keystore":
-                KeystoreAPI.onReceive(this, intent);
+                KeystoreAPI.onReceive(this, context, intent);
                 break;
             case "Location":
                 if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.ACCESS_FINE_LOCATION)) {

--- a/app/src/main/java/com/termux/api/apis/KeystoreAPI.java
+++ b/app/src/main/java/com/termux/api/apis/KeystoreAPI.java
@@ -1,41 +1,65 @@
 package com.termux.api.apis;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyInfo;
 import android.security.keystore.KeyProperties;
-import androidx.annotation.RequiresApi;
 import android.util.Base64;
 import android.util.JsonWriter;
+
+import androidx.annotation.RequiresApi;
 
 import com.termux.api.TermuxApiReceiver;
 import com.termux.api.util.ResultReturner;
 import com.termux.api.util.ResultReturner.ResultJsonWriter;
 import com.termux.api.util.ResultReturner.WithInput;
 import com.termux.shared.logger.Logger;
+import com.termux.shared.settings.preferences.SharedPreferenceUtils;
+import com.termux.shared.termux.settings.preferences.TermuxAPIAppSharedPreferences;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
+import java.security.Key;
 import java.security.KeyFactory;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.KeyStore.Entry;
 import java.security.KeyStore.PrivateKeyEntry;
+import java.security.KeyStore.SecretKeyEntry;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
-import java.security.spec.ECGenParameterSpec;
-import java.security.spec.RSAKeyGenParameterSpec;
+import java.security.spec.AlgorithmParameterSpec;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.stream.Collectors;
 
 public class KeystoreAPI {
 
@@ -43,20 +67,21 @@ public class KeystoreAPI {
 
     // this is the only provider name that is supported by Android
     private static final String PROVIDER = "AndroidKeyStore";
+    private static final String PREFERENCES_PREFIX = "keystore_api__encrypted_data";
 
     @SuppressLint("NewApi")
-    public static void onReceive(TermuxApiReceiver apiReceiver, Intent intent) {
+    public static void onReceive(TermuxApiReceiver apiReceiver, Context context, Intent intent) {
         Logger.logDebug(LOG_TAG, "onReceive");
 
         switch (intent.getStringExtra("command")) {
             case "list":
-                listKeys(apiReceiver, intent);
+                listData(apiReceiver, context, intent);
                 break;
             case "generate":
                 generateKey(apiReceiver, intent);
                 break;
             case "delete":
-                deleteKey(apiReceiver, intent);
+                deleteData(apiReceiver, context, intent);
                 break;
             case "sign":
                 signData(apiReceiver, intent);
@@ -64,24 +89,37 @@ public class KeystoreAPI {
             case "verify":
                 verifyData(apiReceiver, intent);
                 break;
+            case "encrypt":
+                encryptData(apiReceiver, context, intent);
+                break;
+            case "decrypt":
+                decryptData(apiReceiver, context, intent);
+                break;
         }
     }
 
     /**
-     * List the keys inside the keystore.<br>
+     * List either the keys inside the keystore or data in shared preferences.<br>
      * Optional intent extras:
      * <ul>
-     *     <li>detailed: if set, key parameters (modulus etc.) are included in the response</li>
+     *     <li>
+     *         detailed: if set, shows key parameters (modulus etc.)
+     *         or values of shared preferences.
+     *     </li>
+     *     <li>pref: if set, shows shared preferences instead of key parameters.</li>
      * </ul>
      */
     @RequiresApi(api = Build.VERSION_CODES.M)
-    private static void listKeys(TermuxApiReceiver apiReceiver, final Intent intent) {
+    private static void listData(TermuxApiReceiver apiReceiver, final Context context,
+                                 final Intent intent) {
         ResultReturner.returnData(apiReceiver, intent, new ResultJsonWriter() {
             @Override
-            public void writeJson(JsonWriter out) throws GeneralSecurityException, IOException {
+            public void writeJson(JsonWriter out)
+                    throws GeneralSecurityException, IOException, JSONException {
                 KeyStore keyStore = getKeyStore();
                 Enumeration<String> aliases = keyStore.aliases();
-                boolean detailed = intent.getBooleanExtra("detailed", false);
+                boolean detailed = (intent.getIntExtra("detailed", 0) == 1);
+                boolean pref = (intent.getIntExtra("pref", 0) == 1);
 
                 out.beginArray();
                 while (aliases.hasMoreElements()) {
@@ -90,9 +128,36 @@ public class KeystoreAPI {
                     String alias = aliases.nextElement();
                     out.name("alias").value(alias);
 
-                    Entry entry = keyStore.getEntry(alias, null);
-                    if (entry instanceof PrivateKeyEntry) {
-                        printPrivateKey(out, (PrivateKeyEntry) entry, detailed);
+                    if (pref) {
+                        JSONObject prefsJSON = getPrefsJSON(context, alias);
+                        Iterator<String> prefKeys =prefsJSON.keys();
+                        out.name("Preferences");
+                        out.beginObject();
+                            while (prefKeys.hasNext()) {
+                                String transientKey = prefKeys.next();
+                                out.name(transientKey)
+                                   .value(detailed ?
+                                          prefsJSON.getString(transientKey) : "");
+                            }
+                        out.endObject();
+                    } else {
+                        Entry entry = keyStore.getEntry(alias, null);
+                        if (entry instanceof PrivateKeyEntry) {
+                            PrivateKeyEntry privateEntry = (PrivateKeyEntry) entry;
+                            PrivateKey privateKey = privateEntry.getPrivateKey();
+                            PublicKey publicKey = privateEntry.getCertificate().getPublicKey();
+                            String algorithm = privateKey.getAlgorithm();
+                            KeyInfo keyInfo = KeyFactory.getInstance(algorithm)
+                                    .getKeySpec(privateKey, KeyInfo.class);
+                            printKey(out, algorithm, keyInfo, detailed, publicKey);
+                        } else if (entry instanceof SecretKeyEntry) {
+                            SecretKeyEntry secretEntry = (SecretKeyEntry) entry;
+                            SecretKey secretKey = secretEntry.getSecretKey();
+                            String algorithm = secretKey.getAlgorithm();
+                            KeyInfo keyInfo = (KeyInfo) SecretKeyFactory.getInstance(algorithm)
+                                    .getKeySpec(secretKey, KeyInfo.class);
+                            printKey(out, algorithm, keyInfo, detailed, null);
+                        }
                     }
 
                     out.endObject();
@@ -106,60 +171,101 @@ public class KeystoreAPI {
      * Helper function for printing the parameters of a given key.
      */
     @RequiresApi(api = Build.VERSION_CODES.M)
-    private static void printPrivateKey(JsonWriter out, PrivateKeyEntry entry, boolean detailed)
-            throws GeneralSecurityException, IOException {
-        PrivateKey privateKey = entry.getPrivateKey();
-        String algorithm = privateKey.getAlgorithm();
-        KeyInfo keyInfo = KeyFactory.getInstance(algorithm).getKeySpec(privateKey, KeyInfo.class);
+    private static void printKey(JsonWriter out, String algorithm, KeyInfo keyInfo,
+            boolean detailed, Key pubKey) throws GeneralSecurityException, IOException {
+        String mode = String.join(",", keyInfo.getBlockModes());
+        String padding = String.join(",", keyInfo.getEncryptionPaddings());
+        boolean authRequired = keyInfo.isUserAuthenticationRequired();
+        int validityDuration = keyInfo.getUserAuthenticationValidityDurationSeconds();
 
-        PublicKey publicKey = entry.getCertificate().getPublicKey();
-
-        out.name("algorithm").value(algorithm);
+        out.name("algorithm");
+            out.beginObject();
+                out.name("name").value(algorithm);
+                if (!mode.isEmpty()) {
+                    out.name("block_mode").value(mode);
+                    out.name("encryption_padding").value(padding);
+                }
+            out.endObject();
         out.name("size").value(keyInfo.getKeySize());
-
-        if (detailed && publicKey instanceof RSAPublicKey) {
-            RSAPublicKey rsa = (RSAPublicKey) publicKey;
-            // convert to hex
-            out.name("modulus").value(rsa.getModulus().toString(16));
-            out.name("exponent").value(rsa.getPublicExponent().toString(16));
-        }
-        if (detailed && publicKey instanceof ECPublicKey) {
-            ECPublicKey ec = (ECPublicKey) publicKey;
-            // convert to hex
-            out.name("x").value(ec.getW().getAffineX().toString(16));
-            out.name("y").value(ec.getW().getAffineY().toString(16));
-        }
+        out.name("purposes").value(decomposeBinary(keyInfo.getPurposes()));
 
         out.name("inside_secure_hardware").value(keyInfo.isInsideSecureHardware());
 
         out.name("user_authentication");
+            out.beginObject();
+                out.name("required").value(authRequired);
+                out.name("enforced_by_secure_hardware")
+                   .value(keyInfo.isUserAuthenticationRequirementEnforcedBySecureHardware());
+                if (validityDuration >= 0) out.name("validity_duration_seconds")
+                                              .value(validityDuration);
+                if (detailed && authRequired) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                        out.name("authentication_type")
+                           .value(decomposeBinary(keyInfo.getUserAuthenticationType()));
+                    }
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                        out.name("invalidated_by_new_biometric")
+                           .value(keyInfo.isInvalidatedByBiometricEnrollment());
+                    }
+                }
+            out.endObject();
 
-        out.beginObject();
-        out.name("required").value(keyInfo.isUserAuthenticationRequired());
-
-        out.name("enforced_by_secure_hardware");
-        out.value(keyInfo.isUserAuthenticationRequirementEnforcedBySecureHardware());
-
-        int validityDuration = keyInfo.getUserAuthenticationValidityDurationSeconds();
-        if (validityDuration >= 0) {
-            out.name("validity_duration_seconds").value(validityDuration);
+        if (detailed && pubKey instanceof RSAPublicKey) {
+            RSAPublicKey rsa = (RSAPublicKey) pubKey;
+            // convert to hex
+            out.name("modulus").value(rsa.getModulus().toString(16));
+            out.name("exponent").value(rsa.getPublicExponent().toString(16));
         }
-        out.endObject();
+        if (detailed && pubKey instanceof ECPublicKey) {
+            ECPublicKey ec = (ECPublicKey) pubKey;
+            // convert to hex
+            out.name("x").value(ec.getW().getAffineX().toString(16));
+            out.name("y").value(ec.getW().getAffineY().toString(16));
+        }
     }
 
     /**
-     * Permanently delete a key from the keystore.<br>
+     * Decomposes binary for options (e.g. 3->'1|2').
+     */
+    private static String decomposeBinary(int binary) {
+        ArrayList<Integer> values = new ArrayList<>();
+        int power = 0;
+        while (binary != 0) {
+            if ((binary & 1) != 0) values.add(1<<power);
+            power += 1;
+            binary >>= 1;
+        }
+        return values.stream().map(String::valueOf).collect(Collectors.joining("|"));
+    }
+
+    /**
+     * Permanently delete a key from the keystore or a specified shared preference.<br>
      * Required intent extras:
      * <ul>
-     *     <li>alias: key alias</li>
+     *     <li>alias: key alias.</li>
+     *     <li>pref: deletes specified preference of alias instead of key.</li>
      * </ul>
      */
-    private static void deleteKey(TermuxApiReceiver apiReceiver, final Intent intent) {
+    private static void deleteData(TermuxApiReceiver apiReceiver, final Context context,
+                                  final Intent intent) {
         ResultReturner.returnData(apiReceiver, intent, out -> {
             String alias = intent.getStringExtra("alias");
-            // unfortunately this statement does not return anything
-            // nor does it throw an exception if the alias does not exist
-            getKeyStore().deleteEntry(alias);
+            String pref = intent.getStringExtra("pref");
+
+            if (!pref.equals("-1")) {
+                JSONObject prefsJSON = getPrefsJSON(context, alias);
+                prefsJSON.remove(pref);
+                setPrefsJSON(context, alias, prefsJSON);
+            } else {
+                // unfortunately this statement does not return anything
+                // nor does it throw an exception if the alias does not exist
+                getKeyStore().deleteEntry(alias);
+                TermuxAPIAppSharedPreferences.build(context)
+                           .getSharedPreferences()
+                           .edit()
+                           .remove(String.join("__", PREFERENCES_PREFIX, alias))
+                           .commit();
+            }
         });
     }
 
@@ -167,28 +273,53 @@ public class KeystoreAPI {
      * Create a new key inside the keystore.<br>
      * Required intent extras:
      * <ul>
-     *     <li>alias: key alias</li>
+     *     <li>alias: key alias.</li>
      *     <li>
      *         algorithm: key algorithm, should be one of the KeyProperties.KEY_ALGORITHM_*
      *         values, for example {@link KeyProperties#KEY_ALGORITHM_RSA} or
-     *         {@link KeyProperties#KEY_ALGORITHM_EC}.
+     *         {@link KeyProperties#KEY_ALGORITHM_AES}.
      *     </li>
+     *     <li>
+     *         mode: encryption block mode, should be one of the KeyProperties.BLOCK_MODE_*
+     *         values, for example {@link KeyProperties#BLOCK_MODE_GCM} or
+     *         {@link KeyProperties#BLOCK_MODE_CBC}.
+     *     </li>
+     *     <li>
+     *         padding: encryption padding, should be one of the KeyProperties.ENCRYPTION_PADDING_*
+     *         values, for example {@link KeyProperties#ENCRYPTION_PADDING_NONE} or
+     *         {@link KeyProperties#ENCRYPTION_PADDING_PKCS7}. (the full list of supported Cipher
+     *         combinations can be found at
+     *         <a href="https://developer.android.com/training/articles/keystore#SupportedCiphers">
+     *         the Android documentation</a>).
+     *     </li>
+     *     <li>size: key size.</li>
      *     <li>
      *         purposes: purposes of this key, should be a combination of
      *         KeyProperties.PURPOSE_*, for example 12 for
      *         {@link KeyProperties#PURPOSE_SIGN}+{@link KeyProperties#PURPOSE_VERIFY}
+     *         or 3 for
+     *         {@link KeyProperties#PURPOSE_ENCRYPT}+{@link KeyProperties#PURPOSE_DECRYPT}.
      *     </li>
      *     <li>
      *         digests: set of hashes this key can be used with, should be an array of
      *         KeyProperties.DIGEST_* values, for example
-     *         {@link KeyProperties#DIGEST_SHA256} and {@link KeyProperties#DIGEST_SHA512}
+     *         {@link KeyProperties#DIGEST_SHA256} and {@link KeyProperties#DIGEST_SHA512}.
      *     </li>
-     *     <li>size: key size, only used for RSA keys</li>
-     *     <li>curve: elliptic curve name, only used for EC keys</li>
      *     <li>
-     *         userValidity: number of seconds where it is allowed to use this key for signing
-     *         after unlocking the device (re-locking and unlocking restarts the timer), if set to 0
-     *         this feature is disabled (i.e. the key can be used anytime)
+     *         unlocked: set whether key is only valid if device is unlocked.
+     *     </li>
+     *     <li>
+     *         validity: number of seconds where it is allowed to use this key for signing
+     *         after unlocking the device (re-locking and unlocking restarts the timer), if set to
+     *         -1 then key requires authentication for every use.
+     *     </li>
+     *     <li>
+     *         invalidate: set whether new biometric enrollments invalidate the key.
+     *     </li>
+     *     <li>
+     *         auth: key authorizations which can enable key access, for example
+     *         {@link KeyProperties#AUTH_DEVICE_CREDENTIAL} and
+     *         {@link KeyProperties#AUTH_BIOMETRIC_STRONG}.
      *     </li>
      * </ul>
      */
@@ -198,35 +329,51 @@ public class KeystoreAPI {
         ResultReturner.returnData(apiReceiver, intent, out -> {
             String alias = intent.getStringExtra("alias");
             String algorithm = intent.getStringExtra("algorithm");
+            String mode = intent.getStringExtra("mode");
+            String padding = intent.getStringExtra("padding");
+            int size = intent.getIntExtra("size", 2048);
             int purposes = intent.getIntExtra("purposes", 0);
             String[] digests = intent.getStringArrayExtra("digests");
-            int size = intent.getIntExtra("size", 2048);
-            String curve = intent.getStringExtra("curve");
-            int userValidity = intent.getIntExtra("validity", 0);
+            boolean unlocked = (intent.getIntExtra("unlocked", 1) == 1);
+            int userValidity = intent.getIntExtra("validity", -1);
+            boolean invalidate = (intent.getIntExtra("invalidate", 0) == 1);
+            int authorizations = intent.getIntExtra("auth", 0);
 
             KeyGenParameterSpec.Builder builder =
-                    new KeyGenParameterSpec.Builder(alias, purposes);
+                    new KeyGenParameterSpec.Builder(alias, purposes)
+                            .setKeySize(size)
+                            .setUserAuthenticationRequired((authorizations != 0))
+                            .setUserAuthenticationValidityDurationSeconds(userValidity);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                builder.setInvalidatedByBiometricEnrollment(invalidate); //Not working? Cannot turn off invalidation (test with keyInfo.isInvalidatedByBiometricEnrollment())
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    builder.setUnlockedDeviceRequired(unlocked);
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                        builder.setUserAuthenticationParameters(userValidity, authorizations);
+                    }
+                }
+            }
+            if (!mode.equals("-1")) builder.setBlockModes(mode).setEncryptionPaddings(padding);
 
-            builder.setDigests(digests);
-            if (algorithm.equals(KeyProperties.KEY_ALGORITHM_RSA)) {
-                // only the exponent 65537 is supported for now
-                builder.setAlgorithmParameterSpec(
-                        new RSAKeyGenParameterSpec(size, RSAKeyGenParameterSpec.F4));
-                builder.setSignaturePaddings(KeyProperties.SIGNATURE_PADDING_RSA_PKCS1);
+            if (mode.equals(KeyProperties.BLOCK_MODE_ECB) &&
+                    (padding.equals(KeyProperties.ENCRYPTION_PADDING_NONE) ||
+                            padding.equals(KeyProperties.ENCRYPTION_PADDING_PKCS7))) {
+                builder.setRandomizedEncryptionRequired(false);
             }
 
-            if (algorithm.equals(KeyProperties.KEY_ALGORITHM_EC)) {
-                builder.setAlgorithmParameterSpec(new ECGenParameterSpec(curve));
+            if (algorithm.equals(KeyProperties.KEY_ALGORITHM_AES)) {
+                KeyGenerator generator = KeyGenerator.getInstance(algorithm, PROVIDER);
+                generator.init(builder.build());
+                generator.generateKey();
+            } else {
+                builder.setDigests(digests);
+                if (algorithm.equals(KeyProperties.KEY_ALGORITHM_RSA)) {
+                    builder.setSignaturePaddings(KeyProperties.SIGNATURE_PADDING_RSA_PKCS1);
+                }
+                KeyPairGenerator generator = KeyPairGenerator.getInstance(algorithm, PROVIDER);
+                generator.initialize(builder.build());
+                generator.generateKeyPair();
             }
-
-            if (userValidity > 0) {
-                builder.setUserAuthenticationRequired(true);
-                builder.setUserAuthenticationValidityDurationSeconds(userValidity);
-            }
-
-            KeyPairGenerator generator = KeyPairGenerator.getInstance(algorithm, PROVIDER);
-            generator.initialize(builder.build());
-            generator.generateKeyPair();
         });
     }
 
@@ -235,12 +382,12 @@ public class KeystoreAPI {
      * The output is encoded using base64.<br>
      * Required intent extras:
      * <ul>
-     *     <li>alias: key alias</li>
+     *     <li>alias: key alias.</li>
      *     <li>
      *         algorithm: key algorithm and hash combination to use, e.g. SHA512withRSA
      *         (the full list can be found at
      *         <a href="https://developer.android.com/training/articles/keystore#SupportedSignatures">
-     *         the Android documentation</a>)
+     *         the Android documentation</a>).
      *     </li>
      * </ul>
      */
@@ -252,7 +399,8 @@ public class KeystoreAPI {
                 String algorithm = intent.getStringExtra("algorithm");
                 byte[] input = readStream(in);
 
-                PrivateKeyEntry key = (PrivateKeyEntry) getKeyStore().getEntry(alias, null);
+                PrivateKeyEntry key = (PrivateKeyEntry) getKeyStore()
+                                                            .getEntry(alias, null);
                 Signature signature = Signature.getInstance(algorithm);
                 signature.initSign(key.getPrivateKey());
                 signature.update(input);
@@ -270,14 +418,14 @@ public class KeystoreAPI {
      * The file is read from stdin, and a "true" or "false" message is printed to the stdout.<br>
      * Required intent extras:
      * <ul>
-     *     <li>alias: key alias</li>
+     *     <li>alias: key alias.</li>
      *     <li>
      *         algorithm: key algorithm and hash combination that was used to create this signature,
      *         e.g. SHA512withRSA (the full list can be found at
      *         <a href="https://developer.android.com/training/articles/keystore#SupportedSignatures">
-     *         the Android documentation</a>)
+     *         the Android documentation</a>).
      *     </li>
-     *     <li>signature: path of the signature file</li>
+     *     <li>signature: path of the signature file.</li>
      * </ul>
      */
     private static void verifyData(TermuxApiReceiver apiReceiver, final Intent intent) {
@@ -304,6 +452,207 @@ public class KeystoreAPI {
     }
 
     /**
+     * Encrypt a given byte stream.
+     * The data is read from a file or stdin (in that precedence), and the encrypted data is
+     * encoded using base64 then output to stdout and/or shared preferences with a given name.
+     * Output is of the form [IV.length][IV][Encrypted Data] (IV omitted if IV.length is 0).<br>
+     * Required intent extras:
+     * <ul>
+     *     <li>alias: key alias.</li>
+     *     <li>
+     *         algorithm: key algorithm, should be of the form 'ALG/MODE/PADDING'
+     *         (the full list of supported Cipher combinations can be found at
+     *         <a href="https://developer.android.com/training/articles/keystore#SupportedCiphers">
+     *         the Android documentation</a>).
+     *     </li>
+     *     <li>path: the input file containing data to be encrypted.</li>
+     *     <li>store: the name of the shared preference to store the encrypted data.</li>
+     *     <li>quiet: if set, will not output to stdout.</li>
+     * </ul>
+     */
+    private static void encryptData(TermuxApiReceiver apiReceiver, final Context context,
+                                    final Intent intent) {
+        ResultReturner.returnData(apiReceiver, intent, new WithInput() {
+            @Override
+            public void writeResult(PrintWriter out)
+                    throws GeneralSecurityException, IOException, JSONException {
+                String alias = intent.getStringExtra("alias");
+                String algorithm = intent.getStringExtra("algorithm");
+                String path = intent.getStringExtra("filepath");
+                String store = intent.getStringExtra("store");
+                boolean quiet = (intent.getIntExtra("quiet", 0) == 1);
+
+                byte[] input;
+                ByteArrayOutputStream encrypted = new ByteArrayOutputStream();
+
+                if (path.equals("-1")) {
+                    input = readStream(in);
+                } else {
+                    input = readFile(path);
+                }
+
+                String[] alg = algorithm.split("/", 3);
+                Cipher cipher = Cipher.getInstance(algorithm);
+                cipher.init(Cipher.ENCRYPT_MODE, getKey(alias, alg[0], true));
+                byte[] encryptedData = cipher.doFinal(input); Arrays.fill(input, (byte) 0);
+
+                byte[] iv = cipher.getIV();
+                if (iv == null) {
+                    encrypted.write((byte) 0);
+                } else {
+                    encrypted.write(iv.length);
+                    encrypted.write(iv);
+                    Arrays.fill(iv, (byte) 0);
+                }
+                encrypted.write(encryptedData); Arrays.fill(encryptedData, (byte) 0);
+
+                // we are not allowed to output bytes in this function
+                // one option is to encode using base64 which is a plain string
+                if (!quiet) out.write(Base64.encodeToString(
+                                encrypted.toByteArray(), Base64.NO_WRAP));
+                if (!store.equals("-1")) {
+                    JSONObject prefsJSON = getPrefsJSON(context, alias);
+                    prefsJSON.put(store,
+                                  Base64.encodeToString(encrypted.toByteArray(), Base64.NO_WRAP));
+                    setPrefsJSON(context, alias, prefsJSON);
+                }
+                encrypted.reset();
+            }
+        });
+    }
+
+    /**
+     * Decrypt a given byte stream.
+     * The data is read from a file, shared preferences, or stdin (in that precedence), and the
+     * decrypted data can be output to stdout. Input is expected in the form
+     * [IV.length][IV][Encrypted Data] (IV omitted if IV.length is 0).<br>
+     * Required intent extras:
+     * <ul>
+     *     <li>alias: key alias.</li>
+     *     <li>
+     *         algorithm: key algorithm, should be of the form 'ALG/MODE/PADDING'
+     *         (the full list of supported Cipher combinations can be found at
+     *         <a href="https://developer.android.com/training/articles/keystore#SupportedCiphers">
+     *         the Android documentation</a>).
+     *     </li>
+     *     <li>path: the input file containing data to be decrypted.</li>
+     *     <li>store: the name of the shared preference containing data to be decrypted.</li>
+     *     <li>quiet: if set, will not output to stdout.</li>
+     * </ul>
+     */
+    private static void decryptData(TermuxApiReceiver apiReceiver, final Context context,
+                                    final Intent intent) {
+        ResultReturner.returnData(apiReceiver, intent, new WithInput() {
+            @Override
+            public void writeResult(PrintWriter out)
+                    throws GeneralSecurityException, IOException, JSONException {
+                String alias = intent.getStringExtra("alias");
+                String algorithm = intent.getStringExtra("algorithm");
+                String path = intent.getStringExtra("filepath");
+                String store = intent.getStringExtra("store");
+                boolean quiet = (intent.getIntExtra("quiet", 0) == 1);
+
+                byte[] input;
+                ByteArrayOutputStream decrypted = new ByteArrayOutputStream();
+
+                if (path.equals("-1")) {
+                    if (!store.equals("-1")) {
+                        JSONObject prefsJSON = getPrefsJSON(context, alias);
+                        input = Base64.decode(prefsJSON.getString(store), Base64.NO_WRAP);
+                    } else {
+                        input = readStream(in);
+                    }
+                } else {
+                    input = readFile(path);
+                }
+
+                String[] alg = algorithm.split("/", 3);
+                Cipher cipher = Cipher.getInstance(algorithm);
+
+                if (input[0] == 0) {
+                    cipher.init(Cipher.DECRYPT_MODE,
+                            getKey(alias, alg[0], false));
+                } else {
+                    cipher.init(Cipher.DECRYPT_MODE,
+                            getKey(alias, alg[0], false), getIVSpec(input, alg[1]));
+                }
+
+                byte[] decryptedData = cipher.doFinal(input,
+                        input[0]+1, input.length-input[0]-1);
+                Arrays.fill(input, (byte) 0);
+                decrypted.write(decryptedData); Arrays.fill(decryptedData, (byte) 0);
+
+                // we are not allowed to output bytes in this function
+                // one option is to encode using base64 which is a plain string
+                if (!quiet) out.write(Base64.encodeToString(
+                                decrypted.toByteArray(), Base64.NO_WRAP));
+                decrypted.reset();
+            }
+        });
+    }
+
+    /**
+     * Get Shared Preferences in JSON for given key alias.
+     */
+    private static JSONObject getPrefsJSON(Context context, String alias) throws JSONException {
+        SharedPreferences preferences = TermuxAPIAppSharedPreferences.build(context)
+                                                                     .getSharedPreferences();
+        return new JSONObject(SharedPreferenceUtils.getString(preferences,
+                                         String.join("__", PREFERENCES_PREFIX, alias),
+                                         "{}", true));
+    }
+
+    /**
+     * Set Shared Preferences in JSON for given key alias.
+     */
+    private static void setPrefsJSON(Context context, String alias, JSONObject value) {
+        SharedPreferences preferences = TermuxAPIAppSharedPreferences.build(context)
+                                                                     .getSharedPreferences();
+        SharedPreferenceUtils.setString(preferences,
+                                        String.join("__", PREFERENCES_PREFIX, alias),
+                                        value.toString(), true);
+    }
+
+    /**
+     * Get IV Parameter Spec.
+     */
+    private static AlgorithmParameterSpec getIVSpec(byte[] input, String mode) {
+        switch(mode) {
+            case "CBC":
+            case "CTR": {
+                return new IvParameterSpec(input, 1, input[0]);
+            }
+            case "GCM": {
+                return new GCMParameterSpec(128, input, 1, input[0]);
+            }
+            default: throw new IllegalArgumentException(
+                        "Invalid Cipher Block. See: Android keystore#SupportedCiphers");
+        }
+    }
+
+    /**
+     * Get Key.
+     */
+    private static Key getKey(String alias, String algorithm, boolean encrypt)
+            throws GeneralSecurityException, IOException {
+        switch(algorithm) {
+            case "RSA": {
+                PrivateKeyEntry entry =
+                        (PrivateKeyEntry) getKeyStore().getEntry(alias, null);
+                return encrypt ? entry.getCertificate().getPublicKey() : entry.getPrivateKey();
+            }
+            case "AES": {
+                SecretKeyEntry entry =
+                        (SecretKeyEntry) getKeyStore().getEntry(alias, null);
+                return entry.getSecretKey();
+            }
+            default:
+                throw new IllegalArgumentException(
+                        "Invalid Cipher Algorithm. See: Android keystore#SupportedCiphers");
+        }
+    }
+
+    /**
      * Set up and return the keystore.
      */
     private static KeyStore getKeyStore() throws GeneralSecurityException, IOException {
@@ -312,6 +661,21 @@ public class KeystoreAPI {
         return keyStore;
     }
 
+    /**
+     * Read file to byte array.
+     */
+    private static byte[] readFile(String path) throws IOException {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            return Files.readAllBytes(Paths.get(path));
+        } else {
+            File file = new File(path);
+            byte[] data = new byte[(int) file.length()];
+            BufferedInputStream buffer = new BufferedInputStream(new FileInputStream(file));
+            buffer.read(data, 0, data.length);
+            buffer.close();
+            return data;
+        }
+    }
 
     /**
      * Read a given stream to a byte array. Should not be used with large streams.


### PR DESCRIPTION
Fixes #550, resolves #246
Requires https://github.com/termux/termux-api-package/pull/161

+ Receiver receives context, sent to list, delete, encrypt, and decrypt for shared preferences

+ listKeys is now listData and supports showing secret keys and preferences
+ printKey supports secret keys and more KeyInfo parameters

+ deleteKey is now deleteData and supports deleting preferences
+ deleteData deletes all key-associated preferences upon deletion

+ generateKey supports more key parameters (mode, padding, purposes, unlocked, invalidate, auths)
+ generateKey supports secret keys
+ generateKey refactored

+ encryptData added
+ encryptData supports Keystore Ciphers
+ encryptData supports reading from path or stdin
+ encryptData supports writing to shared preferences or stdout
+ encryptData writes output in the form [IV.length][IV][Encrypted Data], if IV.length is 0 then IV omitted
+ encryptedData never exposes data to Strings, stays as byte arrays and is flushed with zeroes after use
+ encryptedData supports a quiet flag so encrypted data does not show in stdout
+ encryptedData supports multiple shared preferences stored as a JSON with a key, value pair
+ encryptedData encodes output to Base64

+ decryptData added
+ decryptData supports Keystore Ciphers
+ decryptData supports reading from path, shared preferences, or stdin
+ decryptData supports writing to stdout
+ decryptData reads output in the form [IV.length][IV][Encrypted Data], if IV.length is 0 then IV omitted
+ decryptedData never exposes data to Strings, stays as byte arrays and is flushed with zeroes after use
+ decryptedData supports a quiet flag so decrypted data does not show in stdout
+ decryptedData supports reading from JSON shared preferences with a key, value pair
+ decryptedData encodes output to Base64

+ decomposeBinary (for purposes and authorizations)
+ getPrefsJSON and setPrefJSON (preferences as JSON)
+ getIVSpec (support different AlgorithmParameterSpecs)
+ getKey (get Public or Secret key for encryption, Private or Secret key for decryption)
+ readFile (also supports Android < 8.0)

+ Replaced ECGenParameterSpec and RSAKeyGenParameterSpec with AlgorithmParameterSpec
- Removed unnecessary imports and casts