### PR TITLE
Added the ability to enable/disable ADB Wi-Fi

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" tools:ignore="ProtectedPermissions"/>
 
     <!-- This permission is not used, but a permission is needed on the sharedfiles contentprovider,
          which will always use FLAG_GRANT_READ_URI_PERMISSION. -->

--- a/app/src/main/java/com/termux/api/TermuxApiReceiver.java
+++ b/app/src/main/java/com/termux/api/TermuxApiReceiver.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.provider.Settings;
 import android.widget.Toast;
 
+import com.termux.api.apis.AdbWifiAPI;
 import com.termux.api.apis.AudioAPI;
 import com.termux.api.apis.BatteryStatusAPI;
 import com.termux.api.apis.BrightnessAPI;
@@ -263,6 +264,11 @@ public class TermuxApiReceiver extends BroadcastReceiver {
                 break;
             case "WifiEnable":
                 WifiAPI.onReceiveWifiEnable(this, context, intent);
+                break;
+            case "AdbWifiEnable":
+                if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.WRITE_SECURE_SETTINGS)) {
+                    AdbWifiAPI.onReceive(this, context, intent);
+                }
                 break;
             default:
                 Logger.logError(LOG_TAG, "Unrecognized 'api_method' extra: '" + apiMethod + "'");

--- a/app/src/main/java/com/termux/api/apis/AdbWifiAPI.java
+++ b/app/src/main/java/com/termux/api/apis/AdbWifiAPI.java
@@ -1,0 +1,26 @@
+package com.termux.api.apis;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.provider.Settings;
+import com.termux.api.TermuxApiReceiver;
+import com.termux.api.util.ResultReturner;
+import com.termux.shared.logger.Logger;
+
+public class AdbWifiAPI {
+
+    private static final String LOG_TAG = "AdbWifiAPI";
+
+    public static void onReceive(final TermuxApiReceiver receiver, final Context context, final Intent intent) {
+        Logger.logDebug(LOG_TAG, "onReceive");
+
+        final ContentResolver contentResolver = context.getContentResolver();
+
+        boolean enabled = intent.getBooleanExtra("enabled", true);
+
+        Settings.Global.putInt(contentResolver, "adb_wifi_enabled", enabled?1:0);
+
+        ResultReturner.noteDone(receiver, intent);
+    }
+}


### PR DESCRIPTION
This commit adds the capability to manage ADB Wi-Fi through termux-api, resolving an issue where users were unable to enable Wi-Fi debugging despite having the WRITE_SECURE_SETTINGS permission in Termux. With this enhancement, users can easily toggle ADB wifi on or off, offering greater flexibility and control in Termux. The WRITE_SECURE_SETTINGS permission must be granted to com.termux.api

Requires
https://github.com/termux/termux-api-package/pull/173
