### PR TITLE
Options for aligning wallpaper to center

### DIFF
--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -1,12 +1,6 @@
 name: Build
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: workflow_dispatch
 
 jobs:
   build:

--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -1,6 +1,12 @@
 name: Build
 
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/app/src/main/java/com/termux/api/apis/WallpaperAPI.java
+++ b/app/src/main/java/com/termux/api/apis/WallpaperAPI.java
@@ -183,7 +183,7 @@ public class WallpaperAPI {
                 paint.setAntiAlias(true);
                 canvas.drawBitmap(originalImage, matrix, paint);
             }
-            return newImage;
+            return (newImage);
         }
 
 

--- a/app/src/main/java/com/termux/api/apis/WallpaperAPI.java
+++ b/app/src/main/java/com/termux/api/apis/WallpaperAPI.java
@@ -117,7 +117,7 @@ public class WallpaperAPI {
         }
 
         protected void onWallpaperResult(final Intent intent, WallpaperResult result) {
-            WallpaperManager wallpaperManager = WallpaperManager.getInstance(context);
+            WallpaperManager wallpaperManager = WallpaperManager.getInstance(getApplicationContext()).setSource(wallpaperSource);
 
             if (result.wallpaper != null) {
                 try {

--- a/app/src/main/java/com/termux/api/apis/WallpaperAPI.java
+++ b/app/src/main/java/com/termux/api/apis/WallpaperAPI.java
@@ -183,7 +183,7 @@ public class WallpaperAPI {
                 paint.setAntiAlias(true);
                 canvas.drawBitmap(originalImage, matrix, paint);
             }
-            return (newImage);
+            return newImage;
         }
 
 

--- a/app/src/main/java/com/termux/api/apis/WallpaperAPI.java
+++ b/app/src/main/java/com/termux/api/apis/WallpaperAPI.java
@@ -117,7 +117,6 @@ public class WallpaperAPI {
         }
 
         protected void onWallpaperResult(final Intent intent, WallpaperResult result) {
-            Context context = getApplicationContext();
             WallpaperManager wallpaperManager = WallpaperManager.getInstance(context);
 
             if (result.wallpaper != null) {


### PR DESCRIPTION
**Additions in termux-wallpaper:**
```bash
show_usage () {
	echo "-c         crop image from center"
	echo "-n         fit full image to screen"
}
...
OPT_CENTER=""
OPT_NOCROP=""
...
while getopts :h,:c,:n,:l,f:,u: option
do
	case "$option" in
		c) OPT_CENTER="true" ;;
		n) OPT_NOCROP="true" ;;
	esac
done
...
[[ -n $OPT_CENTER ]] && [[ -n $OPT_NOCROP ]] && echo "$SCRIPTNAME: must specify either -c or -n" && exit 1 ;
...
set --
[ -n "$OPT_CENTER" ] && set -- "$@" --ez center "$OPT_CENTER"
[ -n "$OPT_NOCROP" ] && set -- "$@" --ez nocrop "$OPT_NOCROP"
/data/data/com.termux/files/usr/libexec/termux-api Wallpaper "$@"
```

**Tested images:** 


[Vertical image](https://github.com/termux/termux-api/assets/110735449/27f874e5-9160-43b5-be0e-c687cd091606)

[Vertical in portrait -c](https://github.com/termux/termux-api/assets/110735449/be42a36a-51b4-4ca9-8aba-1aa81b206ff7)
[Vertical in portrait -n](https://github.com/termux/termux-api/assets/110735449/66e038de-e9b9-42cf-9214-87d2bc187e41)
[Vertical in landscape -c](https://github.com/termux/termux-api/assets/110735449/3cef501b-6b6b-4424-a940-1e7fafd6e359)
[Vertical in landscape -n](https://github.com/termux/termux-api/assets/110735449/97508d94-9b69-4372-b4ea-bdcc79b85baf)



[Horizontal image](https://github.com/termux/termux-api/assets/110735449/e0926ff2-9606-47b2-aebe-737bb090e4ec)

[Horizontal in portrait -c](https://github.com/termux/termux-api/assets/110735449/ef80ebd9-575d-42e3-aa83-06fcc9f4205f)
[Horizontal in portrait -n](https://github.com/termux/termux-api/assets/110735449/66623114-3a94-4511-a28f-e277691b1c45)
[Horizontal in landscape -c](https://github.com/termux/termux-api/assets/110735449/2346377f-9a4e-4a33-95f4-a61762b19db6)
[Horizontal in landscape -n](https://github.com/termux/termux-api/assets/110735449/f61de3df-7bbc-4169-8276-1a2415288111)


~~Is this the format I'm supposed to use?~~
And please, ignore unnecessary commits. This is my first time of actually using Github.