### PR TITLE
fix(JobSchedulerApi): handle null object on `--network none`

### DIFF
--- a/app/src/main/java/com/termux/api/apis/JobSchedulerAPI.java
+++ b/app/src/main/java/com/termux/api/apis/JobSchedulerAPI.java
@@ -8,6 +8,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.net.NetworkRequest;
 import android.os.Build;
 import android.os.PersistableBundle;
 import androidx.annotation.RequiresApi;
@@ -53,7 +54,8 @@ public class JobSchedulerAPI {
             }
         }
         if (Build.VERSION.SDK_INT >= 28) {
-            description.add(String.format(Locale.ENGLISH, "(network: %s)", jobInfo.getRequiredNetwork().toString()));
+            final NetworkRequest network = jobInfo.getRequiredNetwork();
+            description.add(String.format(Locale.ENGLISH, "(network: %s)", network == null ? "none" : network.toString()));
         }
 
         return String.format(Locale.ENGLISH, "Job %d: %s\t%s", jobInfo.getId(), path,


### PR DESCRIPTION
Can be reproduced with `termux-job-scheduler -s ~/script.sh --network none`