### PR TITLE
Expose last-modified times

### DIFF
--- a/app/src/main/java/com/termux/api/apis/SAFAPI.java
+++ b/app/src/main/java/com/termux/api/apis/SAFAPI.java
@@ -288,8 +288,14 @@ public class SAFAPI {
             }
 
             out.name("uri");
-
             out.value(uri.toString());
+
+            index = c.getColumnIndex(DocumentsContract.Document.COLUMN_LAST_MODIFIED);
+            if (index >= 0) {
+                out.name("last_modified");
+                out.value(c.getLong(index));
+            }
+
             if (mime != null && !DocumentsContract.Document.MIME_TYPE_DIR.equals(mime)) {
                 index = c.getColumnIndex(DocumentsContract.Document.COLUMN_SIZE);
                 if (index >= 0) {


### PR DESCRIPTION
This exposes the last modified times of files, where available, to commands like `termux-saf-ls` and `termux-saf-stat`.

I wrote https://github.com/BryanJacobs/saf_sync/ but it's badly hampered by not being able to see file modification times. Exposing this already-available information would avoid unnecessary copies.

Example output when testing with a real Termux on an actual Android device:

```
  {
    "name": "myfile.bin",
    "type": "application/octet-stream",
    "uri": "content://com.android.externalstorage.documents/tree/primary%3Atest/document/primary%3Atest%2Fmyfile.bin",
    "length": 384,
    "last_modified": 2126636192
  },
```