### PR TITLE
Improve sensor name matching by looking for best match

### DIFF
--- a/app/src/main/java/com/termux/api/apis/SensorAPI.java
+++ b/app/src/main/java/com/termux/api/apis/SensorAPI.java
@@ -287,16 +287,24 @@ public class SensorAPI {
             } else {
 
                 // try to find matching sensors that were sent in request
-                for (String sensorName : requestedSensors) {
+                for (String requestedSensor : requestedSensors) {
                     // ignore case
-                    sensorName = sensorName.toUpperCase();
+                    requestedSensor = requestedSensor.toUpperCase();
 
-                    for (Sensor sensor : availableSensors) {
-                        if (sensor.getName().toUpperCase().contains(sensorName)) {
-                            sensorManager.registerListener(sensorEventListener, sensor, SensorManager.SENSOR_DELAY_UI);
-                            sensorsToListenTo.add(sensor);
-                            break;
+                    Sensor shortestMatchSensor = null;
+                    int shortestMatchSensorLength = Integer.MAX_VALUE;
+
+                    for (Sensor availableSensor : availableSensors) {
+                        String sensorName = availableSensor.getName().toUpperCase();
+                        if (sensorName.contains(requestedSensor) && sensorName.length() < shortestMatchSensorLength) {
+                            shortestMatchSensor = availableSensor;
+                            shortestMatchSensorLength = sensorName.length();
                         }
+                    }
+
+                    if (shortestMatchSensor != null) {
+                        sensorManager.registerListener(sensorEventListener, shortestMatchSensor, SensorManager.SENSOR_DELAY_UI);
+                        sensorsToListenTo.add(shortestMatchSensor);
                     }
                 }
             }


### PR DESCRIPTION
Hello, feel free to review and make changes :)

This fixes an issue where having both ORIENTATION and DEVICE_ORIENTATION sensors makes it impossible to select ORIENTATION with the -s flag, as noted here: https://github.com/termux/termux-api/issues/570

It should also help prevent similar issues.