### PR TITLE
termux-memory: exit reason and available memory

### DIFF
--- a/app/src/main/java/com/termux/api/TermuxApiReceiver.java
+++ b/app/src/main/java/com/termux/api/TermuxApiReceiver.java
@@ -25,6 +25,7 @@ import com.termux.api.apis.KeystoreAPI;
 import com.termux.api.apis.LocationAPI;
 import com.termux.api.apis.MediaPlayerAPI;
 import com.termux.api.apis.MediaScannerAPI;
+import com.termux.api.apis.MemAPI;
 import com.termux.api.apis.MicRecorderAPI;
 import com.termux.api.apis.NfcAPI;
 import com.termux.api.apis.NotificationAPI;
@@ -159,6 +160,9 @@ public class TermuxApiReceiver extends BroadcastReceiver {
             case "MediaScanner":
                 MediaScannerAPI.onReceive(this, context, intent);
                 break;
+            case "Memory":
+                MemAPI.onReceive(this, context, intent);
+                break;    
             case "MicRecorder":
                 if (TermuxApiPermissionActivity.checkAndRequestPermissions(context, intent, Manifest.permission.RECORD_AUDIO)) {
                     MicRecorderAPI.onReceive(context, intent);

--- a/app/src/main/java/com/termux/api/apis/MemAPI.java
+++ b/app/src/main/java/com/termux/api/apis/MemAPI.java
@@ -1,0 +1,103 @@
+package com.termux.api.apis;
+
+import android.app.ActivityManager;
+import android.app.ActivityManager.MemoryInfo;
+import android.app.ApplicationExitInfo;
+import android.content.Context;
+import android.os.Build;
+import android.os.Bundle;
+import android.content.Context;
+import android.content.Intent;
+import android.util.JsonWriter;
+
+import androidx.annotation.RequiresPermission;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.termux.api.TermuxApiReceiver;
+import com.termux.api.util.ResultReturner;
+import com.termux.shared.logger.Logger;
+
+import java.util.List;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class MemAPI {
+
+	private static final String LOG_TAG = "MemAPI";
+	static Context context;
+	static JsonWriter out;
+	static TermuxApiReceiver receiver;
+	static Intent intent;
+	static StringWriter sw;
+
+	public static void onReceive(TermuxApiReceiver _receiver, final Context _context, Intent _intent) {
+		Logger.logDebug(LOG_TAG, "onReceive");
+		context = _context;
+		receiver = _receiver;
+		intent = _intent;
+		sw = new StringWriter();
+		out = new JsonWriter(sw);
+
+		out.setIndent("  ");
+
+		try {
+			out.beginObject();
+			exitReason();
+			appMem();
+			totalMem();
+			out.endObject();
+			write();
+			Logger.logInfo(LOG_TAG, sw.toString());
+		} catch (Exception e) {
+			Logger.logError(LOG_TAG, e.getMessage());
+		}
+	}
+
+	static void write() {
+		ResultReturner.returnData(context.getApplicationContext(), intent, new ResultReturner.WithInput() {
+			@Override public void writeResult(PrintWriter _out) throws Exception {
+				try {
+					_out.print(sw);
+				} catch (Exception e) {
+					Logger.logError(LOG_TAG, e.getMessage());
+				}
+			}
+		});
+	}
+		
+	static void exitReason() throws Exception {
+		out.name("exitReason");
+		out.beginArray();
+		final ActivityManager am = context.getSystemService(ActivityManager.class);
+		List<ApplicationExitInfo> list = am.getHistoricalProcessExitReasons("com.termux", 0, 10);
+		//out.name("Exit reason").value (i.toString());
+		for (ApplicationExitInfo i : list) {	
+			out.value(i.toString());
+		}
+		out.endArray();
+	}
+
+	static void appMem() throws Exception {
+		Runtime rt = Runtime.getRuntime();
+		out.name("appMem");
+		out.beginObject();
+		out.name("freeMemory").value(rt.freeMemory()/1024/1024);
+		out.name("maxMemory").value(rt.maxMemory()/1024/1024);
+		out.name("totalMemory").value(rt.totalMemory()/1024/1024);
+		out.endObject();
+	}
+
+	static void totalMem() throws Exception {
+		out.name("totalMem");
+		out.beginObject();
+		final ActivityManager am = context.getSystemService(ActivityManager.class);
+		MemoryInfo mem = new
+ ActivityManager.MemoryInfo();
+		am.getMemoryInfo(mem);
+		out.name("availMem").value(mem.availMem/1024/1024);
+		out.name("lowMemory").value(mem.lowMemory);
+		out.name("threshold").value(mem.threshold/1024/1024);
+		out.name("totalMem").value(mem.totalMem/1024/1024);
+		out.endObject();
+	}
+}


### PR DESCRIPTION
this will print all memory info available without adb. it turned out to be a disappointment and closing as useless. only adb can give more info 

the exit reason is LOW_MEMORY with empty description . there is no more memory info without adb

sample output 

```
$PREFIX/libexec/termux-api Memory
{
  "exitReason": [
    "ApplicationExitInfo(timestamp=24/07/2024, 01:38 pid=16125 realUid=10214 packageUid=10214 definingUid=10214 user=0 process=com.termux reason=13 (OTHER KILLS BY SYSTEM) subreason=3 (TOO MANY EMPTY PROCS) status=0 importance=400 pss=24MB rss=77MB description=too many empty state=empty trace=null",
    "ApplicationExitInfo(timestamp=24/07/2024, 01:38 pid=15301 realUid=10214 packageUid=10214 definingUid=10214 user=0 process=com.termux reason=3 (LOW_MEMORY) subreason=0 (UNKNOWN) status=0 importance=400 pss=0.00 rss=0.00 description=null state=empty trace=null",
    "ApplicationExitInfo(timestamp=24/07/2024, 01:37 pid=23926 realUid=10214 packageUid=10214 definingUid=10214 user=0 process=com.termux reason=2 (SIGNALED) subreason=0 (UNKNOWN) status=9 importance=125 pss=75MB rss=128MB description=null state=empty trace=null"
  ],
  "appMem": {
    "freeMemory": 385,
    "maxMemory": 388,
    "totalMemory": 388
  },
  "totalMem": {
    "availMem": 945,
    "lowMemory": false,
    "threshold": 300,
    "totalMem": 3470
  }
}
```

similar information can already be obtained from existing commands without adb

```
cat /proc/meminfo|grep Mem
MemTotal:        3553360 kB
MemFree:           46344 kB
MemAvailable:     704540 kB

free -h
               total        used        free      shared  buff/cache   available
Mem:           3.4Gi       2.3Gi        42Mi        25Mi       1.0Gi       820Mi
Swap:          2.0Gi       1.2Gi       826Mi

am start -n com.android.settings/com.android.settings.Settings\$AppMemoryUsageActivity
```

# termux permissions 

these are all the permissions that accomplish the same thing 

exit info can be granted to termux

```
pm grant com.termux android.permission.DUMP
pm grant com.termux android.permission.PACKAGE_USAGE_STATS
dumpsys activity exit-info com.termux
ACTIVITY MANAGER PROCESS EXIT INFO (dumpsys activity exit-info)                         Last Timestamp of Persistence Into Persistent Storage: 2024-07-24 22:24:05.492            package: com.termux                           Historical Process Exit for uid=10190           ApplicationExitInfo #0:                       timestamp=2024-07-24 23:17:22.764 pid=5678 realUid=10190 packageUid=10190 definingUid=10190 user=0                                  process=com.termux reason=8 (PERMISSION CHANGE) subreason=0 (UNKNOWN) status=0          importance=100 pss=70MB rss=183MB description=permission grant or revoke changed gids state=empty trace=null
```

i had to click allow here but had no gui. `emulator ... -qemu -vnc :0` vnc is disabled in the goldfish emulator so no gui. it has to be granted every time it used from gui

```
pm grant com.termux android.permission.READ_LOGS
logcat -d |grep lowmem
<no GUI can't accept permission>
```

this is not allowed in production builds. this  will grant a memory log without adb in emulator  by disabling security enhancement but binder still enabled 

```
adb root
setenforce 0
dumpsys meminfo
```

running services can be shown from the gui only every command i tried failed even with debugging enabled

```
am start -n com.android.settings/com.android.settings.RunningServices

am start -n com.android.settings/com.android.settings.Settings\$RunningServicesActivity

am start -n com.android.settings/.SubSettings -e :settings:show_fragment com.android.settings.applications.RunningServices
```

# localhost adbd

i wrote this to confirm that i need adb to debug my problem . i have no computer or wifi and hence no adb. my phone has memory problems. firefox is sometimes terminated from the foreground and AppMemoryUsageActivity show 600 meg max for firefox. logcat|grep lowmem confirm the kill of 0 oom score foreground app. it has reached 3400 meg sometimes . i have to investigate the memory usage of 200 programs that my phone is running all the time that can't be killed. when they gradually leak firefox is eventually killed at 600 meg. the stress program has reached 2600 meg of 3600 total on another occasion 

i am working on removing the wifi checks for wireless debugging. the toggle button block is in WirelessDebuggingEnabler.java. there is another check that disable it when wifi disconnect that i haven't found. after that hopefully the menus will still show the port number despite there being no wifi ip address

 termux debug through localhost and wifi is irrelevant 

```
settings put global airplane_mode_on 1
settings put global adb_wifi_enabled 1
adb pair localhost:1234
adb connect localhost:1234
```





