### PR TITLE
Stop `termux-notification --button1-action` previous execution overwrite

### DIFF
--- a/app/src/main/java/com/termux/api/apis/NotificationAPI.java
+++ b/app/src/main/java/com/termux/api/apis/NotificationAPI.java
@@ -31,6 +31,7 @@ import com.termux.shared.termux.TermuxConstants.TERMUX_APP.TERMUX_SERVICE;
 import java.io.File;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -406,8 +407,8 @@ public class NotificationAPI {
 
     static Intent createExecuteIntent(String action){
         ExecutionCommand executionCommand = new ExecutionCommand();
-        executionCommand.executableUri = new Uri.Builder().scheme(TERMUX_SERVICE.URI_SCHEME_SERVICE_EXECUTE).path(BIN_SH).build();
         executionCommand.arguments = new String[]{"-c", action};
+        executionCommand.executableUri = new Uri.Builder().scheme(TERMUX_SERVICE.URI_SCHEME_SERVICE_EXECUTE).path(BIN_SH).appendQueryParameter("arguments", Arrays.toString(executionCommand.arguments)).build();
         executionCommand.runner = ExecutionCommand.Runner.APP_SHELL.getName();
 
         // Create execution intent with the action TERMUX_SERVICE#ACTION_SERVICE_EXECUTE to be sent to the TERMUX_SERVICE


### PR DESCRIPTION
https://github.com/termux/termux-api/commit/3bea194249586a7dcb143e66b46c1694cb6ca21a#diff-343e04246aa27ee11598690b750ef754846d37f1107456982925ae4526689ce7 introduces the issue.

Last commit has the issue:

https://github.com/user-attachments/assets/b1bfceb9-9f95-4839-87d1-beb56a132dab

While this pull requests solves the issue by restoring [v0.50.1](https://github.com/termux/termux-api/releases/tag/v0.50.1) behavior:

https://github.com/user-attachments/assets/7c5febae-35c0-442d-96cb-3f9f59cce271

Bash function used:

```bash
notification-test() {
    termux-notification -t "Test $1" --button1 "Button $1" --button1-action "echo Button $1 >> termux_notification_action.txt"
}
```

```bash
notification-test 0
```

Tested on Fairphone 4 LineageOS 21 with Termux app [c2d57f2ed810b6fa854a6c9ab0ecee4aac38a0cc](https://github.com/termux/termux-app/commit/c2d57f2ed810b6fa854a6c9ab0ecee4aac38a0cc).

More details at [Benjamin-Loison/termux-api/issues/23](https://github.com/Benjamin-Loison/termux-api/issues/23).