### PR TITLE
[RFC] get ip addresses through connectivity manager, and get gateway ip as well

### DIFF
--- a/app/src/main/java/com/termux/api/apis/WifiAPI.java
+++ b/app/src/main/java/com/termux/api/apis/WifiAPI.java
@@ -4,11 +4,13 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.location.LocationManager;
+import android.net.ConnectivityManager;
+import android.net.LinkProperties;
+import android.net.LinkAddress;
 import android.net.wifi.ScanResult;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.text.TextUtils;
-import android.text.format.Formatter;
 import android.util.JsonWriter;
 
 import com.termux.api.TermuxApiReceiver;
@@ -30,14 +32,17 @@ public class WifiAPI {
             public void writeJson(JsonWriter out) throws Exception {
                 WifiManager manager = (WifiManager) context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
                 WifiInfo info = manager.getConnectionInfo();
+                ConnectivityManager connManager = (ConnectivityManager) context.getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+                LinkProperties linkProperties = connManager.getLinkProperties(connManager.getActiveNetwork());
                 out.beginObject();
                 if (info == null) {
                     out.name("API_ERROR").value("No current connection");
                 } else {
+                    for (LinkAddress address: linkProperties.getLinkAddresses()) {
+                        out.name("ip").value(address.getAddress().getHostAddress());
+                    }
                     out.name("bssid").value(info.getBSSID());
                     out.name("frequency_mhz").value(info.getFrequency());
-                    //noinspection deprecation - formatIpAddress is deprecated, but we only have a ipv4 address here:
-                    out.name("ip").value(Formatter.formatIpAddress(info.getIpAddress()));
                     out.name("link_speed_mbps").value(info.getLinkSpeed());
                     out.name("mac_address").value(info.getMacAddress());
                     out.name("network_id").value(info.getNetworkId());

--- a/app/src/main/java/com/termux/api/apis/WifiAPI.java
+++ b/app/src/main/java/com/termux/api/apis/WifiAPI.java
@@ -7,6 +7,7 @@ import android.location.LocationManager;
 import android.net.ConnectivityManager;
 import android.net.LinkProperties;
 import android.net.LinkAddress;
+import android.net.RouteInfo;
 import android.net.wifi.ScanResult;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
@@ -40,6 +41,11 @@ public class WifiAPI {
                 } else {
                     for (LinkAddress address: linkProperties.getLinkAddresses()) {
                         out.name("ip").value(address.getAddress().getHostAddress());
+                    }
+                    for (RouteInfo routeInfo: linkProperties.getRoutes()) {
+                        if (routeInfo.isDefaultRoute() && routeInfo.hasGateway()) {
+                            out.name("gateway").value(routeInfo.getGateway().getHostAddress());
+                        }
                     }
                     out.name("bssid").value(info.getBSSID());
                     out.name("frequency_mhz").value(info.getFrequency());


### PR DESCRIPTION
Through connectivity manager we can get both ipv4 and ipv6 addresses, and can drop the use of the deprecated `Formatter.formatIpAddress()`.

With both changes we get something like:

```
$ termux-wifi-connectioninfo 
{
  "ip": "fe80::7cf7:74ff:fe65:52be",
  "ip": "192.168.1.224",
  "ip": "fd6e:e697:d22e:0:7cf7:74ff:fe65:52be",
  "ip": "fd6e:e697:d22e:0:d536:328f:b0f:1a32",
  "gateway": "192.168.1.1",
  "bssid": "02:00:00:00:00:00",
  "frequency_mhz": 2452,
  "link_speed_mbps": 78,
  "mac_address": "02:00:00:00:00:00",
  "network_id": -1,
  "rssi": -57,
  "ssid": "<unknown ssid>",
  "ssid_hidden": false,
  "supplicant_state": "COMPLETED"
}
```

Going from just one ip field to several will likely break some user scripts though. Maybe we should keep printing the IPV4 address as `"ip" : ...` and then all of them as `"ip 1" : ...`, `"ip 2" : ...` and so on? 