### PR TITLE
Fix #828: Add accessibility API

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -177,6 +177,19 @@
             android:exported="false" />
 
         <service
+            android:name=".TermuxAccessibilityService"
+            android:enabled="true"
+            android:exported="false"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_service_config"/>
+        </service>
+
+        <service
             android:name=".apis.JobSchedulerAPI$JobSchedulerService"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false" />

--- a/app/src/main/java/com/termux/api/TermuxAccessibilityService.java
+++ b/app/src/main/java/com/termux/api/TermuxAccessibilityService.java
@@ -1,0 +1,26 @@
+package com.termux.api;
+
+import com.termux.shared.logger.Logger;
+
+import android.accessibilityservice.AccessibilityService;
+import android.view.accessibility.AccessibilityEvent;
+
+public class TermuxAccessibilityService extends AccessibilityService {
+
+    private static final String LOG_TAG = "AccessibilityService";
+
+	public static TermuxAccessibilityService instance;
+
+    @Override
+    protected void onServiceConnected() {
+        super.onServiceConnected();
+        Logger.logDebug(LOG_TAG, "onServiceConnected");
+        instance = this;
+    }
+
+    @Override
+    public void onAccessibilityEvent(AccessibilityEvent event) {}
+
+    @Override
+    public void onInterrupt() {}
+}

--- a/app/src/main/java/com/termux/api/TermuxApiReceiver.java
+++ b/app/src/main/java/com/termux/api/TermuxApiReceiver.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.provider.Settings;
 import android.widget.Toast;
 
+import com.termux.api.apis.AccessibilityAPI;
 import com.termux.api.apis.AudioAPI;
 import com.termux.api.apis.BatteryStatusAPI;
 import com.termux.api.apis.BrightnessAPI;
@@ -84,6 +85,9 @@ public class TermuxApiReceiver extends BroadcastReceiver {
         }
 
         switch (apiMethod) {
+            case "Accessibility":
+                AccessibilityAPI.onReceive(this, context, intent);
+                break;
             case "AudioInfo":
                 AudioAPI.onReceive(this, context, intent);
                 break;

--- a/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
+++ b/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
@@ -38,6 +38,7 @@ import android.accessibilityservice.AccessibilityServiceInfo;
 import android.content.pm.ServiceInfo;
 import java.util.List;
 import android.accessibilityservice.AccessibilityService;
+import android.os.Bundle;
 
 public class AccessibilityAPI {
 
@@ -57,9 +58,10 @@ public class AccessibilityAPI {
 			final ContentResolver contentResolver = context.getContentResolver();
 			if (intent.hasExtra("dump")) {
 				out.print(dump());
-			}
-			else if (intent.hasExtra("click")) {
+			} else if (intent.hasExtra("click")) {
 				click(intent.getIntExtra("x", 0), intent.getIntExtra("y", 0));
+			} else if (intent.hasExtra("type")) {
+				type(intent.getStringExtra("type"));
 			}
 		});
 	}
@@ -170,5 +172,12 @@ public class AccessibilityAPI {
 
 	private static String getCharSequenceAsString(CharSequence charSequence) {
 		return charSequence != null ? charSequence.toString() : "";
+	}
+
+	private static void type(String toType) {
+		AccessibilityNodeInfo focusedNode = TermuxAccessibilityService.instance.getRootInActiveWindow().findFocus(AccessibilityNodeInfo.FOCUS_INPUT);
+        Bundle arguments = new Bundle();
+        arguments.putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, toType);
+        focusedNode.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, arguments);
 	}
 }

--- a/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
+++ b/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
@@ -116,6 +116,8 @@ public class AccessibilityAPI {
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+        // Necessary to not have surrogate pairs for emojis, see [Benjamin_Loison/Voice_assistant/issues/83#issue-3661619](https://codeberg.org/Benjamin_Loison/Voice_assistant/issues/83#issue-3661619)
+        transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-16");
         DOMSource source = new DOMSource(document);
 
         StringWriter sw = new StringWriter();

--- a/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
+++ b/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
@@ -124,6 +124,11 @@ public class AccessibilityAPI {
 	private static void dumpNodeAuxiliary(Document document, Element element, AccessibilityNodeInfo node) {
 		for (int i = 0; i < node.getChildCount(); i++) {
 			AccessibilityNodeInfo nodeChild = node.getChild(i);
+			// May be faced randomly, see [Benjamin-Loison/android/issues/28#issuecomment-3975714760](https://github.com/Benjamin-Loison/android/issues/28#issuecomment-3975714760)
+			if (nodeChild == null)
+			{
+				continue;
+			}
 			Element elementChild = document.createElement("node");
 			
 			elementChild.setAttribute("index", String.valueOf(i));

--- a/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
+++ b/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
@@ -62,6 +62,8 @@ public class AccessibilityAPI {
 				click(intent.getIntExtra("x", 0), intent.getIntExtra("y", 0));
 			} else if (intent.hasExtra("type")) {
 				type(intent.getStringExtra("type"));
+			} else if (intent.hasExtra("global-action")) {
+                performGlobalAction(intent.getStringExtra("global-action"));
 			}
 		});
 	}
@@ -179,5 +181,9 @@ public class AccessibilityAPI {
         Bundle arguments = new Bundle();
         arguments.putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, toType);
         focusedNode.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, arguments);
+	}
+
+	private static void performGlobalAction(String globalAction) throws NoSuchFieldException, IllegalAccessException {
+		TermuxAccessibilityService.instance.performGlobalAction((int)AccessibilityService.class.getDeclaredField("GLOBAL_ACTION_" + globalAction).get(null));
 	}
 }

--- a/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
+++ b/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
@@ -1,0 +1,145 @@
+package com.termux.api.apis;
+
+import android.content.Context;
+import android.content.Intent;
+
+import com.termux.api.TermuxApiReceiver;
+import com.termux.api.util.ResultReturner;
+import com.termux.shared.logger.Logger;
+
+import java.io.PrintWriter;
+
+import com.termux.api.TermuxAccessibilityService;
+import android.view.accessibility.AccessibilityNodeInfo;
+import android.accessibilityservice.GestureDescription;
+import android.graphics.Path;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import java.io.StringWriter;
+
+import android.graphics.Rect;
+
+import android.content.ContentResolver;
+
+public class AccessibilityAPI {
+
+    private static final String LOG_TAG = "AccessibilityAPI";
+
+    public static void onReceive(TermuxApiReceiver apiReceiver, final Context context, Intent intent) {
+        Logger.logDebug(LOG_TAG, "onReceive");
+
+		ResultReturner.returnData(apiReceiver, intent, out -> {
+			final ContentResolver contentResolver = context.getContentResolver();
+			if (intent.hasExtra("dump")) {
+				out.print(dump());
+			}
+			else if (intent.hasExtra("click")) {
+				click(intent.getIntExtra("x", 0), intent.getIntExtra("y", 0));
+			}
+		});
+	}
+
+	private static void click(int x, int y) {
+		Path swipePath = new Path();
+	    swipePath.moveTo(x, y);
+	    GestureDescription.Builder gestureBuilder = new GestureDescription.Builder();
+	    gestureBuilder.addStroke(new GestureDescription.StrokeDescription(swipePath, 0, 1));
+	    TermuxAccessibilityService.instance.dispatchGesture(gestureBuilder.build(), null, null);
+	}
+
+	// The aim of this function is to give a compatible output with `adb` `uiautomator dump`.
+	private static String dump() throws TransformerException, ParserConfigurationException {
+		// Create a DocumentBuilder
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+
+        // Create a new Document
+        Document document = builder.newDocument();
+
+        // Create root element
+        Element root = document.createElement("hierarchy");
+        document.appendChild(root);
+
+		AccessibilityNodeInfo node = TermuxAccessibilityService.instance.getRootInActiveWindow();
+
+		dumpNodeAuxiliary(document, root, node);
+
+        // Write as XML
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        Transformer transformer = transformerFactory.newTransformer();
+		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+		transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+        DOMSource source = new DOMSource(document);
+
+		StringWriter sw = new StringWriter();
+        StreamResult result = new StreamResult(sw);
+        transformer.transform(source, result);
+
+		return sw.toString();
+	}
+
+	private static void dumpNodeAuxiliary(Document document, Element element, AccessibilityNodeInfo node) {
+		for (int i = 0; i < node.getChildCount(); i++) {
+			AccessibilityNodeInfo nodeChild = node.getChild(i);
+			Element elementChild = document.createElement("node");
+			
+			elementChild.setAttribute("index", String.valueOf(i));
+
+			elementChild.setAttribute("text", getCharSequenceAsString(nodeChild.getText()));
+
+			String nodeChildViewIdResourceName = nodeChild.getViewIdResourceName();
+			elementChild.setAttribute("resource-id", nodeChildViewIdResourceName != null ? nodeChildViewIdResourceName : "");
+			
+			elementChild.setAttribute("class", nodeChild.getClassName().toString());
+			
+			elementChild.setAttribute("package", nodeChild.getPackageName().toString());
+
+			elementChild.setAttribute("content-desc", getCharSequenceAsString(nodeChild.getContentDescription()));
+			
+			elementChild.setAttribute("checkable", String.valueOf(nodeChild.isCheckable()));
+			
+			elementChild.setAttribute("checked", String.valueOf(nodeChild.isChecked()));
+			
+			elementChild.setAttribute("clickable", String.valueOf(nodeChild.isClickable()));
+			
+			elementChild.setAttribute("enabled", String.valueOf(nodeChild.isEnabled()));
+			
+			elementChild.setAttribute("focusable", String.valueOf(nodeChild.isFocusable()));
+			
+			elementChild.setAttribute("focused", String.valueOf(nodeChild.isFocused()));
+			
+			elementChild.setAttribute("scrollable", String.valueOf(nodeChild.isScrollable()));
+			
+			elementChild.setAttribute("long-clickable", String.valueOf(nodeChild.isLongClickable()));
+			
+			elementChild.setAttribute("password", String.valueOf(nodeChild.isPassword()));
+			
+			elementChild.setAttribute("selected", String.valueOf(nodeChild.isSelected()));
+			
+			Rect nodeChildBounds = new Rect();
+			nodeChild.getBoundsInScreen(nodeChildBounds);
+			elementChild.setAttribute("bounds", nodeChildBounds.toShortString());
+			
+			elementChild.setAttribute("drawing-order", String.valueOf(nodeChild.getDrawingOrder()));
+			
+			elementChild.setAttribute("hint", getCharSequenceAsString(nodeChild.getHintText()));
+			
+			element.appendChild(elementChild);
+            dumpNodeAuxiliary(document, elementChild, nodeChild);
+        }
+	}
+
+	private static String getCharSequenceAsString(CharSequence charSequence) {
+		return charSequence != null ? charSequence.toString() : "";
+	}
+}

--- a/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
+++ b/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
@@ -59,7 +59,7 @@ public class AccessibilityAPI {
             if (intent.hasExtra("dump")) {
                 out.print(dump());
             } else if (intent.hasExtra("click")) {
-                click(intent.getIntExtra("x", 0), intent.getIntExtra("y", 0));
+                click(intent.getIntExtra("x", 0), intent.getIntExtra("y", 0), intent.getIntExtra("duration", 1));
             } else if (intent.hasExtra("type")) {
                 type(intent.getStringExtra("type"));
             } else if (intent.hasExtra("global-action")) {
@@ -82,11 +82,11 @@ public class AccessibilityAPI {
         return false;
     }
 
-    private static void click(int x, int y) {
+    private static void click(int x, int y, int millisecondsDuration) {
         Path swipePath = new Path();
         swipePath.moveTo(x, y);
         GestureDescription.Builder gestureBuilder = new GestureDescription.Builder();
-        gestureBuilder.addStroke(new GestureDescription.StrokeDescription(swipePath, 0, 1));
+        gestureBuilder.addStroke(new GestureDescription.StrokeDescription(swipePath, 0, millisecondsDuration));
         TermuxAccessibilityService.instance.dispatchGesture(gestureBuilder.build(), null, null);
     }
 

--- a/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
+++ b/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
@@ -36,6 +36,9 @@ import android.accessibilityservice.AccessibilityServiceInfo;
 import android.content.pm.ServiceInfo;
 import java.util.List;
 import android.accessibilityservice.AccessibilityService;
+import android.view.accessibility.AccessibilityWindowInfo;
+import android.util.SparseArray;
+
 import android.os.Bundle;
 
 import android.view.Display;
@@ -62,10 +65,12 @@ public class AccessibilityAPI {
             context.startActivity(accessibilityIntent);
         }
 
+		int displayId = intent.getIntExtra("display-id", Display.DEFAULT_DISPLAY);
+
 		if (intent.hasExtra("dump")) {
-			dump(apiReceiver, intent);
+			dump(apiReceiver, intent, displayId);
 		} else if (intent.hasExtra("click")) {
-			click(intent.getIntExtra("x", 0), intent.getIntExtra("y", 0), intent.getIntExtra("duration", 1));
+			click(intent.getIntExtra("x", 0), intent.getIntExtra("y", 0), intent.getIntExtra("duration", 1), displayId);
 			returnEmptyString(apiReceiver, intent);
 		} else if (intent.hasExtra("type")) {
 			type(intent.getStringExtra("type"));
@@ -74,7 +79,7 @@ public class AccessibilityAPI {
 			performGlobalAction(intent.getStringExtra("global-action"));
 			returnEmptyString(apiReceiver, intent);
 		} else if (intent.hasExtra("screenshot")) {
-			screenshot(apiReceiver, context, intent);
+			screenshot(apiReceiver, context, intent, displayId);
 		}
     }
 
@@ -97,18 +102,21 @@ public class AccessibilityAPI {
         return false;
     }
 
-    private static void click(int x, int y, int millisecondsDuration) {
+    private static void click(int x, int y, int millisecondsDuration, int displayId) {
         Path swipePath = new Path();
         swipePath.moveTo(x, y);
         GestureDescription.Builder gestureBuilder = new GestureDescription.Builder();
+		gestureBuilder.setDisplayId(displayId);
         gestureBuilder.addStroke(new GestureDescription.StrokeDescription(swipePath, 0, millisecondsDuration));
         TermuxAccessibilityService.instance.dispatchGesture(gestureBuilder.build(), null, null);
     }
 
     // The aim of this function is to give a compatible output with `adb` `uiautomator dump`.
-    private static void dump(TermuxApiReceiver apiReceiver, Intent intent) {
-        AccessibilityNodeInfo node = TermuxAccessibilityService.instance.getRootInActiveWindow();
-        // On Signal *App permissions* for instance
+    private static void dump(TermuxApiReceiver apiReceiver, Intent intent, int displayId) {
+        SparseArray<List<AccessibilityWindowInfo>> windowsOnAllDisplays = TermuxAccessibilityService.instance.getWindowsOnAllDisplays();
+		List<AccessibilityWindowInfo> windowsOnDisplay = windowsOnAllDisplays.get(displayId);
+        AccessibilityNodeInfo node = windowsOnDisplay.getLast().getRoot();
+		// On Signal *App permissions* for instance
         if (node == null) {
 			ResultReturner.returnData(apiReceiver, intent, out -> {});
             return;
@@ -225,10 +233,22 @@ public class AccessibilityAPI {
     }
 
     private static void type(String toType) {
-        AccessibilityNodeInfo focusedNode = TermuxAccessibilityService.instance.getRootInActiveWindow().findFocus(AccessibilityNodeInfo.FOCUS_INPUT);
-        Bundle arguments = new Bundle();
-        arguments.putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, toType);
-        focusedNode.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, arguments);
+		SparseArray<List<AccessibilityWindowInfo>> windowsOnAllDisplays = TermuxAccessibilityService.instance.getWindowsOnAllDisplays();
+		for(int windowsOnAllDisplayIndex = 0; windowsOnAllDisplayIndex < windowsOnAllDisplays.size(); windowsOnAllDisplayIndex++)
+        {
+            List<AccessibilityWindowInfo> windowsOnAllDisplay = windowsOnAllDisplays.valueAt(windowsOnAllDisplayIndex);
+            for(AccessibilityWindowInfo accessibilityWindowInfo : windowsOnAllDisplay)
+			{
+				AccessibilityNodeInfo focusedNode = accessibilityWindowInfo.getRoot().findFocus(AccessibilityNodeInfo.FOCUS_INPUT);
+				if(focusedNode != null)
+				{
+					Bundle arguments = new Bundle();
+					arguments.putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, toType);
+					focusedNode.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, arguments);
+					return;
+				}
+			}
+		}
     }
 
     private static void performGlobalAction(String globalActionString) {
@@ -249,9 +269,9 @@ public class AccessibilityAPI {
         TermuxAccessibilityService.instance.performGlobalAction(globalActionInt);
     }
 
-	private static void screenshot(TermuxApiReceiver apiReceiver, final Context context, Intent intent) {
+	private static void screenshot(TermuxApiReceiver apiReceiver, final Context context, Intent intent, int displayId) {
 		TermuxAccessibilityService.instance.takeScreenshot(
-            Display.DEFAULT_DISPLAY,
+            displayId,
             context.getMainExecutor(),
             new TakeScreenshotCallback() {
 

--- a/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
+++ b/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
@@ -181,7 +181,7 @@ public class AccessibilityAPI {
             String nodeChildViewIdResourceName = nodeChild.getViewIdResourceName();
             elementChild.setAttribute("resource-id", nodeChildViewIdResourceName != null ? nodeChildViewIdResourceName : "");
 
-            elementChild.setAttribute("class", nodeChild.getClassName().toString());
+            elementChild.setAttribute("class", getCharSequenceAsString(nodeChild.getClassName()));
 
             elementChild.setAttribute("package", nodeChild.getPackageName().toString());
 

--- a/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
+++ b/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
@@ -195,6 +195,6 @@ public class AccessibilityAPI {
     }
 
     private static void performGlobalAction(String globalAction) throws NoSuchFieldException, IllegalAccessException {
-        TermuxAccessibilityService.instance.performGlobalAction((int)AccessibilityService.class.getDeclaredField("GLOBAL_ACTION_" + globalAction).get(null));
+        TermuxAccessibilityService.instance.performGlobalAction((int)AccessibilityService.class.getDeclaredField("GLOBAL_ACTION_" + globalAction.toUpperCase()).get(null));
     }
 }

--- a/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
+++ b/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
@@ -29,8 +29,6 @@ import java.io.StringWriter;
 
 import android.graphics.Rect;
 
-import android.content.ContentResolver;
-
 import android.provider.Settings;
 
 import android.view.accessibility.AccessibilityManager;
@@ -39,6 +37,16 @@ import android.content.pm.ServiceInfo;
 import java.util.List;
 import android.accessibilityservice.AccessibilityService;
 import android.os.Bundle;
+
+import android.view.Display;
+import android.accessibilityservice.AccessibilityService.TakeScreenshotCallback;
+import android.accessibilityservice.AccessibilityService.ScreenshotResult;
+import android.hardware.HardwareBuffer;
+import android.graphics.ColorSpace;
+import android.graphics.Bitmap;
+import java.io.OutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
 
 public class AccessibilityAPI {
 
@@ -54,19 +62,26 @@ public class AccessibilityAPI {
             context.startActivity(accessibilityIntent);
         }
 
-        ResultReturner.returnData(apiReceiver, intent, out -> {
-            final ContentResolver contentResolver = context.getContentResolver();
-            if (intent.hasExtra("dump")) {
-                out.print(dump());
-            } else if (intent.hasExtra("click")) {
-                click(intent.getIntExtra("x", 0), intent.getIntExtra("y", 0), intent.getIntExtra("duration", 1));
-            } else if (intent.hasExtra("type")) {
-                type(intent.getStringExtra("type"));
-            } else if (intent.hasExtra("global-action")) {
-                performGlobalAction(intent.getStringExtra("global-action"));
-            }
-        });
+		if (intent.hasExtra("dump")) {
+			dump(apiReceiver, intent);
+		} else if (intent.hasExtra("click")) {
+			click(intent.getIntExtra("x", 0), intent.getIntExtra("y", 0), intent.getIntExtra("duration", 1));
+			returnEmptyString(apiReceiver, intent);
+		} else if (intent.hasExtra("type")) {
+			type(intent.getStringExtra("type"));
+			returnEmptyString(apiReceiver, intent);
+		} else if (intent.hasExtra("global-action")) {
+			performGlobalAction(intent.getStringExtra("global-action"));
+			returnEmptyString(apiReceiver, intent);
+		} else if (intent.hasExtra("screenshot")) {
+			screenshot(apiReceiver, context, intent);
+		}
     }
+
+	// Necessary for void functions not to hang.
+	private static void returnEmptyString(TermuxApiReceiver apiReceiver, Intent intent) {
+		ResultReturner.returnData(apiReceiver, intent, out -> {});
+	}
 
     // [The Stack Overflow answer 14923144](https://stackoverflow.com/a/14923144)
     public static boolean isAccessibilityServiceEnabled(Context context, Class<? extends AccessibilityService> service) {
@@ -91,10 +106,30 @@ public class AccessibilityAPI {
     }
 
     // The aim of this function is to give a compatible output with `adb` `uiautomator dump`.
-    private static String dump() throws TransformerException, ParserConfigurationException {
-        // Create a DocumentBuilder
+    private static void dump(TermuxApiReceiver apiReceiver, Intent intent) {
+        AccessibilityNodeInfo node = TermuxAccessibilityService.instance.getRootInActiveWindow();
+        // On Signal *App permissions* for instance
+        if (node == null) {
+			ResultReturner.returnData(apiReceiver, intent, out -> {});
+            return;
+        }
+
+		String swString = dumpAuxiliary(node);
+
+		ResultReturner.returnData(apiReceiver, intent, out -> {
+			out.write(swString);
+		});
+    }
+
+	private static String dumpAuxiliary(AccessibilityNodeInfo node) {
+		// Create a DocumentBuilder
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = factory.newDocumentBuilder();
+        DocumentBuilder builder = null;
+        try {
+            builder = factory.newDocumentBuilder();
+        } catch (ParserConfigurationException parserConfigurationException) {
+            Logger.logDebug(LOG_TAG, "ParserConfigurationException");
+        }
 
         // Create a new Document
         Document document = builder.newDocument();
@@ -103,17 +138,16 @@ public class AccessibilityAPI {
         Element root = document.createElement("hierarchy");
         document.appendChild(root);
 
-        AccessibilityNodeInfo node = TermuxAccessibilityService.instance.getRootInActiveWindow();
-        // On Signal *App permissions* for instance
-        if (node == null) {
-            return "";
-        }
-
         dumpNodeAuxiliary(document, root, node);
 
         // Write as XML
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
-        Transformer transformer = transformerFactory.newTransformer();
+        Transformer transformer = null;
+        try {
+            transformer = transformerFactory.newTransformer();
+        } catch (TransformerException transformerException) {
+            Logger.logDebug(LOG_TAG, "TransformerException transformerFactory.newTransformer");
+        }
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
         // Necessary to not have surrogate pairs for emojis, see [Benjamin_Loison/Voice_assistant/issues/83#issue-3661619](https://codeberg.org/Benjamin_Loison/Voice_assistant/issues/83#issue-3661619)
@@ -122,10 +156,13 @@ public class AccessibilityAPI {
 
         StringWriter sw = new StringWriter();
         StreamResult result = new StreamResult(sw);
-        transformer.transform(source, result);
-
-        return sw.toString();
-    }
+        try {
+            transformer.transform(source, result);
+        } catch (TransformerException transformerException) {
+            Logger.logDebug(LOG_TAG, "TransformerException transformer.transform");
+        }
+		return sw.toString();
+	}
 
     private static void dumpNodeAuxiliary(Document document, Element element, AccessibilityNodeInfo node) {
         for (int i = 0; i < node.getChildCount(); i++) {
@@ -194,7 +231,52 @@ public class AccessibilityAPI {
         focusedNode.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, arguments);
     }
 
-    private static void performGlobalAction(String globalAction) throws NoSuchFieldException, IllegalAccessException {
-        TermuxAccessibilityService.instance.performGlobalAction((int)AccessibilityService.class.getDeclaredField("GLOBAL_ACTION_" + globalAction.toUpperCase()).get(null));
+    private static void performGlobalAction(String globalActionString) {
+		String fieldName = "GLOBAL_ACTION_" + globalActionString.toUpperCase();
+		Field field = null;
+		try {
+			field = AccessibilityService.class.getDeclaredField(fieldName);
+		} catch (NoSuchFieldException noSuchFieldException) {
+			Logger.logDebug(LOG_TAG, "NoSuchFieldException");
+		}
+		Object globalActionObject = null;
+		try {
+			globalActionObject = field.get(null);
+		} catch(IllegalAccessException illegalAccessException) {
+			Logger.logDebug(LOG_TAG, "IllegalAccessException");
+		}
+		int globalActionInt = (int)globalActionObject;
+        TermuxAccessibilityService.instance.performGlobalAction(globalActionInt);
     }
+
+	private static void screenshot(TermuxApiReceiver apiReceiver, final Context context, Intent intent) {
+		TermuxAccessibilityService.instance.takeScreenshot(
+            Display.DEFAULT_DISPLAY,
+            context.getMainExecutor(),
+            new TakeScreenshotCallback() {
+
+                @Override
+                public void onSuccess(ScreenshotResult screenshotResult) {
+                    Logger.logDebug(LOG_TAG, "onSuccess");
+                    HardwareBuffer buffer = screenshotResult.getHardwareBuffer();
+                    ColorSpace colorSpace = screenshotResult.getColorSpace();
+
+                    Bitmap bitmap = Bitmap.wrapHardwareBuffer(buffer, colorSpace);
+
+                    ResultReturner.returnData(apiReceiver, intent, new ResultReturner.BinaryOutput()
+                    {
+                        @Override
+                        public void writeResult(OutputStream out) throws IOException {
+                            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
+                        }
+                    });
+                }
+
+                @Override
+                public void onFailure(int errorCode) {
+                    Logger.logDebug(LOG_TAG, "onFailure: " + errorCode);
+                }
+            }
+        );
+	}
 }

--- a/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
+++ b/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
@@ -51,6 +51,11 @@ import java.io.OutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
 
+import android.hardware.display.DisplayManager;
+import android.util.JsonWriter;
+import com.termux.api.util.ResultReturner.ResultJsonWriter;
+import android.graphics.Point;
+
 public class AccessibilityAPI {
 
     private static final String LOG_TAG = "AccessibilityAPI";
@@ -80,6 +85,27 @@ public class AccessibilityAPI {
 			returnEmptyString(apiReceiver, intent);
 		} else if (intent.hasExtra("screenshot")) {
 			screenshot(apiReceiver, context, intent, displayId);
+		} else if (intent.hasExtra("list-displays")) {
+			ResultReturner.returnData(apiReceiver, intent, new ResultJsonWriter() {
+				@Override
+				public void writeJson(final JsonWriter out) throws Exception {
+					out.beginArray();
+					DisplayManager displayManager = (DisplayManager)context.getSystemService(Context.DISPLAY_SERVICE);
+					for(Display display : displayManager.getDisplays()) {
+						out.beginObject();
+						out.name("id").value(display.getDisplayId());
+						out.name("name").value(display.getName());
+						out.name("refresh_rate").value(display.getRefreshRate());
+						out.name("flags").value(display.getFlags());
+						Point size = new Point();
+						display.getSize(size);
+						out.name("height").value(size.y);
+						out.name("width").value(size.x);
+						out.endObject();
+					}
+					out.endArray();
+				}
+			});
 		}
     }
 

--- a/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
+++ b/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
@@ -104,7 +104,7 @@ public class AccessibilityAPI {
         document.appendChild(root);
 
         AccessibilityNodeInfo node = TermuxAccessibilityService.instance.getRootInActiveWindow();
-        // Randomly faced [Benjamin_Loison/Voice_assistant/issues/84#issue-3661682](https://codeberg.org/Benjamin_Loison/Voice_assistant/issues/84#issue-3661682)
+        // On Signal *App permissions* for instance
         if (node == null) {
             return "";
         }

--- a/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
+++ b/app/src/main/java/com/termux/api/apis/AccessibilityAPI.java
@@ -47,52 +47,52 @@ public class AccessibilityAPI {
     public static void onReceive(TermuxApiReceiver apiReceiver, final Context context, Intent intent) {
         Logger.logDebug(LOG_TAG, "onReceive");
 
-		boolean isAccessibilityEnabled = isAccessibilityServiceEnabled(context, TermuxAccessibilityService.class);
-		if (!isAccessibilityEnabled) {
-			Intent accessibilityIntent = new Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS);
-			accessibilityIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-			context.startActivity(accessibilityIntent);
-		}
+        boolean isAccessibilityEnabled = isAccessibilityServiceEnabled(context, TermuxAccessibilityService.class);
+        if (!isAccessibilityEnabled) {
+            Intent accessibilityIntent = new Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS);
+            accessibilityIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            context.startActivity(accessibilityIntent);
+        }
 
-		ResultReturner.returnData(apiReceiver, intent, out -> {
-			final ContentResolver contentResolver = context.getContentResolver();
-			if (intent.hasExtra("dump")) {
-				out.print(dump());
-			} else if (intent.hasExtra("click")) {
-				click(intent.getIntExtra("x", 0), intent.getIntExtra("y", 0));
-			} else if (intent.hasExtra("type")) {
-				type(intent.getStringExtra("type"));
-			} else if (intent.hasExtra("global-action")) {
+        ResultReturner.returnData(apiReceiver, intent, out -> {
+            final ContentResolver contentResolver = context.getContentResolver();
+            if (intent.hasExtra("dump")) {
+                out.print(dump());
+            } else if (intent.hasExtra("click")) {
+                click(intent.getIntExtra("x", 0), intent.getIntExtra("y", 0));
+            } else if (intent.hasExtra("type")) {
+                type(intent.getStringExtra("type"));
+            } else if (intent.hasExtra("global-action")) {
                 performGlobalAction(intent.getStringExtra("global-action"));
-			}
-		});
-	}
+            }
+        });
+    }
 
-	// [The Stack Overflow answer 14923144](https://stackoverflow.com/a/14923144)
-	public static boolean isAccessibilityServiceEnabled(Context context, Class<? extends AccessibilityService> service) {
-		AccessibilityManager am = (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
-		List<AccessibilityServiceInfo> enabledServices = am.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK);
+    // [The Stack Overflow answer 14923144](https://stackoverflow.com/a/14923144)
+    public static boolean isAccessibilityServiceEnabled(Context context, Class<? extends AccessibilityService> service) {
+        AccessibilityManager am = (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
+        List<AccessibilityServiceInfo> enabledServices = am.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK);
 
-		for (AccessibilityServiceInfo enabledService : enabledServices) {
-			ServiceInfo enabledServiceInfo = enabledService.getResolveInfo().serviceInfo;
-			if (enabledServiceInfo.packageName.equals(context.getPackageName()) && enabledServiceInfo.name.equals(service.getName()))
-				return true;
-		}
+        for (AccessibilityServiceInfo enabledService : enabledServices) {
+            ServiceInfo enabledServiceInfo = enabledService.getResolveInfo().serviceInfo;
+            if (enabledServiceInfo.packageName.equals(context.getPackageName()) && enabledServiceInfo.name.equals(service.getName()))
+                return true;
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	private static void click(int x, int y) {
-		Path swipePath = new Path();
-	    swipePath.moveTo(x, y);
-	    GestureDescription.Builder gestureBuilder = new GestureDescription.Builder();
-	    gestureBuilder.addStroke(new GestureDescription.StrokeDescription(swipePath, 0, 1));
-	    TermuxAccessibilityService.instance.dispatchGesture(gestureBuilder.build(), null, null);
-	}
+    private static void click(int x, int y) {
+        Path swipePath = new Path();
+        swipePath.moveTo(x, y);
+        GestureDescription.Builder gestureBuilder = new GestureDescription.Builder();
+        gestureBuilder.addStroke(new GestureDescription.StrokeDescription(swipePath, 0, 1));
+        TermuxAccessibilityService.instance.dispatchGesture(gestureBuilder.build(), null, null);
+    }
 
-	// The aim of this function is to give a compatible output with `adb` `uiautomator dump`.
-	private static String dump() throws TransformerException, ParserConfigurationException {
-		// Create a DocumentBuilder
+    // The aim of this function is to give a compatible output with `adb` `uiautomator dump`.
+    private static String dump() throws TransformerException, ParserConfigurationException {
+        // Create a DocumentBuilder
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         DocumentBuilder builder = factory.newDocumentBuilder();
 
@@ -103,92 +103,96 @@ public class AccessibilityAPI {
         Element root = document.createElement("hierarchy");
         document.appendChild(root);
 
-		AccessibilityNodeInfo node = TermuxAccessibilityService.instance.getRootInActiveWindow();
+        AccessibilityNodeInfo node = TermuxAccessibilityService.instance.getRootInActiveWindow();
+        // Randomly faced [Benjamin_Loison/Voice_assistant/issues/84#issue-3661682](https://codeberg.org/Benjamin_Loison/Voice_assistant/issues/84#issue-3661682)
+        if (node == null) {
+            return "";
+        }
 
-		dumpNodeAuxiliary(document, root, node);
+        dumpNodeAuxiliary(document, root, node);
 
         // Write as XML
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
         Transformer transformer = transformerFactory.newTransformer();
-		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-		transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
         DOMSource source = new DOMSource(document);
 
-		StringWriter sw = new StringWriter();
+        StringWriter sw = new StringWriter();
         StreamResult result = new StreamResult(sw);
         transformer.transform(source, result);
 
-		return sw.toString();
-	}
+        return sw.toString();
+    }
 
-	private static void dumpNodeAuxiliary(Document document, Element element, AccessibilityNodeInfo node) {
-		for (int i = 0; i < node.getChildCount(); i++) {
-			AccessibilityNodeInfo nodeChild = node.getChild(i);
-			// May be faced randomly, see [Benjamin-Loison/android/issues/28#issuecomment-3975714760](https://github.com/Benjamin-Loison/android/issues/28#issuecomment-3975714760)
-			if (nodeChild == null)
-			{
-				continue;
-			}
-			Element elementChild = document.createElement("node");
-			
-			elementChild.setAttribute("index", String.valueOf(i));
+    private static void dumpNodeAuxiliary(Document document, Element element, AccessibilityNodeInfo node) {
+        for (int i = 0; i < node.getChildCount(); i++) {
+            AccessibilityNodeInfo nodeChild = node.getChild(i);
+            // May be faced randomly, see [Benjamin-Loison/android/issues/28#issuecomment-3975714760](https://github.com/Benjamin-Loison/android/issues/28#issuecomment-3975714760)
+            if (nodeChild == null)
+            {
+                continue;
+            }
+            Element elementChild = document.createElement("node");
 
-			elementChild.setAttribute("text", getCharSequenceAsString(nodeChild.getText()));
+            elementChild.setAttribute("index", String.valueOf(i));
 
-			String nodeChildViewIdResourceName = nodeChild.getViewIdResourceName();
-			elementChild.setAttribute("resource-id", nodeChildViewIdResourceName != null ? nodeChildViewIdResourceName : "");
-			
-			elementChild.setAttribute("class", nodeChild.getClassName().toString());
-			
-			elementChild.setAttribute("package", nodeChild.getPackageName().toString());
+            elementChild.setAttribute("text", getCharSequenceAsString(nodeChild.getText()));
 
-			elementChild.setAttribute("content-desc", getCharSequenceAsString(nodeChild.getContentDescription()));
-			
-			elementChild.setAttribute("checkable", String.valueOf(nodeChild.isCheckable()));
-			
-			elementChild.setAttribute("checked", String.valueOf(nodeChild.isChecked()));
-			
-			elementChild.setAttribute("clickable", String.valueOf(nodeChild.isClickable()));
-			
-			elementChild.setAttribute("enabled", String.valueOf(nodeChild.isEnabled()));
-			
-			elementChild.setAttribute("focusable", String.valueOf(nodeChild.isFocusable()));
-			
-			elementChild.setAttribute("focused", String.valueOf(nodeChild.isFocused()));
-			
-			elementChild.setAttribute("scrollable", String.valueOf(nodeChild.isScrollable()));
-			
-			elementChild.setAttribute("long-clickable", String.valueOf(nodeChild.isLongClickable()));
-			
-			elementChild.setAttribute("password", String.valueOf(nodeChild.isPassword()));
-			
-			elementChild.setAttribute("selected", String.valueOf(nodeChild.isSelected()));
-			
-			Rect nodeChildBounds = new Rect();
-			nodeChild.getBoundsInScreen(nodeChildBounds);
-			elementChild.setAttribute("bounds", nodeChildBounds.toShortString());
-			
-			elementChild.setAttribute("drawing-order", String.valueOf(nodeChild.getDrawingOrder()));
-			
-			elementChild.setAttribute("hint", getCharSequenceAsString(nodeChild.getHintText()));
-			
-			element.appendChild(elementChild);
+            String nodeChildViewIdResourceName = nodeChild.getViewIdResourceName();
+            elementChild.setAttribute("resource-id", nodeChildViewIdResourceName != null ? nodeChildViewIdResourceName : "");
+
+            elementChild.setAttribute("class", nodeChild.getClassName().toString());
+
+            elementChild.setAttribute("package", nodeChild.getPackageName().toString());
+
+            elementChild.setAttribute("content-desc", getCharSequenceAsString(nodeChild.getContentDescription()));
+
+            elementChild.setAttribute("checkable", String.valueOf(nodeChild.isCheckable()));
+
+            elementChild.setAttribute("checked", String.valueOf(nodeChild.isChecked()));
+
+            elementChild.setAttribute("clickable", String.valueOf(nodeChild.isClickable()));
+
+            elementChild.setAttribute("enabled", String.valueOf(nodeChild.isEnabled()));
+
+            elementChild.setAttribute("focusable", String.valueOf(nodeChild.isFocusable()));
+
+            elementChild.setAttribute("focused", String.valueOf(nodeChild.isFocused()));
+
+            elementChild.setAttribute("scrollable", String.valueOf(nodeChild.isScrollable()));
+
+            elementChild.setAttribute("long-clickable", String.valueOf(nodeChild.isLongClickable()));
+
+            elementChild.setAttribute("password", String.valueOf(nodeChild.isPassword()));
+
+            elementChild.setAttribute("selected", String.valueOf(nodeChild.isSelected()));
+
+            Rect nodeChildBounds = new Rect();
+            nodeChild.getBoundsInScreen(nodeChildBounds);
+            elementChild.setAttribute("bounds", nodeChildBounds.toShortString());
+
+            elementChild.setAttribute("drawing-order", String.valueOf(nodeChild.getDrawingOrder()));
+
+            elementChild.setAttribute("hint", getCharSequenceAsString(nodeChild.getHintText()));
+
+            element.appendChild(elementChild);
             dumpNodeAuxiliary(document, elementChild, nodeChild);
         }
-	}
+    }
 
-	private static String getCharSequenceAsString(CharSequence charSequence) {
-		return charSequence != null ? charSequence.toString() : "";
-	}
+    private static String getCharSequenceAsString(CharSequence charSequence) {
+        return charSequence != null ? charSequence.toString() : "";
+    }
 
-	private static void type(String toType) {
-		AccessibilityNodeInfo focusedNode = TermuxAccessibilityService.instance.getRootInActiveWindow().findFocus(AccessibilityNodeInfo.FOCUS_INPUT);
+    private static void type(String toType) {
+        AccessibilityNodeInfo focusedNode = TermuxAccessibilityService.instance.getRootInActiveWindow().findFocus(AccessibilityNodeInfo.FOCUS_INPUT);
         Bundle arguments = new Bundle();
         arguments.putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, toType);
         focusedNode.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, arguments);
-	}
+    }
 
-	private static void performGlobalAction(String globalAction) throws NoSuchFieldException, IllegalAccessException {
-		TermuxAccessibilityService.instance.performGlobalAction((int)AccessibilityService.class.getDeclaredField("GLOBAL_ACTION_" + globalAction).get(null));
-	}
+    private static void performGlobalAction(String globalAction) throws NoSuchFieldException, IllegalAccessException {
+        TermuxAccessibilityService.instance.performGlobalAction((int)AccessibilityService.class.getDeclaredField("GLOBAL_ACTION_" + globalAction).get(null));
+    }
 }

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:canRetrieveWindowContent="true"
+	android:accessibilityFlags="flagReportViewIds"
+	android:canPerformGestures="true"/>

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -2,5 +2,5 @@
 <accessibility-service
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	android:canRetrieveWindowContent="true"
-	android:accessibilityFlags="flagReportViewIds"
+	android:accessibilityFlags="flagReportViewIds|flagIncludeNotImportantViews"
 	android:canPerformGestures="true"/>

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -3,4 +3,5 @@
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	android:canRetrieveWindowContent="true"
 	android:accessibilityFlags="flagReportViewIds|flagIncludeNotImportantViews"
-	android:canPerformGestures="true"/>
+	android:canPerformGestures="true"
+	android:canTakeScreenshot="true"/>

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -2,6 +2,6 @@
 <accessibility-service
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	android:canRetrieveWindowContent="true"
-	android:accessibilityFlags="flagReportViewIds|flagIncludeNotImportantViews"
+	android:accessibilityFlags="flagReportViewIds|flagIncludeNotImportantViews|flagRetrieveInteractiveWindows"
 	android:canPerformGestures="true"
 	android:canTakeScreenshot="true"/>


### PR DESCRIPTION
See #837.

[Benjamin_Loison/xmlstarlet/issues/4](https://codeberg.org/Benjamin_Loison/xmlstarlet/issues/4) may show a possible UTF-8/16 mismatch.

<details>
<summary>Personal notes:</summary>

```
adb shell cmd accessibility
```
<details>
<summary>Output:</summary>

```
Accessibility service (accessibility) commands:
  help
    Print this help text.
  set-bind-instant-service-allowed [--user <USER_ID>] true|false 
    Set whether binding to services provided by instant apps is allowed.
  get-bind-instant-service-allowed [--user <USER_ID>]
    Get whether binding to services provided by instant apps is allowed.
  call-system-action <ACTION_ID>
    Calls the system action with the given action id.
  check-hidraw [read|write|descriptor] <HIDRAW_NODE_PATH>
    Checks if the system can perform various actions on the HIDRAW node.
  start-trace [-t LOGGING_TYPE [LOGGING_TYPE...]]
    Start the debug tracing. If no option is present, full trace will be
    generated. Options are:
      -t: Only generate tracing for the logging type(s) specified here.
          LOGGING_TYPE can be any one of below:
            IAccessibilityServiceConnection
            IAccessibilityServiceClient
            IAccessibilityManager
            IAccessibilityManagerClient
            IAccessibilityInteractionConnection
            IAccessibilityInteractionConnectionCallback
            IRemoteMagnificationAnimationCallback
            IMagnificationConnection
            IMagnificationConnectionCallback
            WindowManagerInternal
            WindowsForAccessibilityCallback
            MagnificationCallbacks
            InputFilter
            Gesture
            AccessibilityService
            PMBroadcastReceiver
            UserBroadcastReceiver
            FingerprintGesture
  stop-trace
    Stop the debug tracing.
```
</details>

may help.
</details>