### PR TITLE
Make TTS write to stdout when one line is said

### DIFF
--- a/app/src/main/java/com/termux/api/apis/TextToSpeechAPI.java
+++ b/app/src/main/java/com/termux/api/apis/TextToSpeechAPI.java
@@ -188,13 +188,14 @@ public class TextToSpeechAPI {
                                 if (!line.isEmpty()) {
                                     submittedUtterances++;
                                     mTts.speak(line, TextToSpeech.QUEUE_ADD, params, utteranceId);
+									synchronized (ttsDoneUtterancesCount) {
+										while (ttsDoneUtterancesCount.get() != submittedUtterances) {
+											ttsDoneUtterancesCount.wait();
+										}
+									}
+									out.println("spoken");
+									out.flush();
                                 }
-                            }
-                        }
-
-                        synchronized (ttsDoneUtterancesCount) {
-                            while (ttsDoneUtterancesCount.get() != submittedUtterances) {
-                                ttsDoneUtterancesCount.wait();
                             }
                         }
                     } catch (Exception e) {


### PR DESCRIPTION
To keep TTS engine initialized, as it takes about 1,611 (2.437s - 0.826s) seconds to initialize, and to know when to start a TTS to avoid overlapping audios or TTS being detected as voice input to `termux-speech-to-text`.

Related to [termux/termux-api-package/issues/148](https://github.com/termux/termux-api-package/issues/148).

Would help [Benjamin_Loison/Voice_assistant/issues/66](https://codeberg.org/Benjamin_Loison/Voice_assistant/issues/66).