### PR TITLE
BrightnessAPI: return current brightness when no arguments are provided

### DIFF
--- a/app/src/main/java/com/termux/api/apis/BrightnessAPI.java
+++ b/app/src/main/java/com/termux/api/apis/BrightnessAPI.java
@@ -17,6 +17,17 @@ public class BrightnessAPI {
         Logger.logDebug(LOG_TAG, "onReceive");
 
         final ContentResolver contentResolver = context.getContentResolver();
+        if (!intent.hasExtra("brightness") && !intent.hasExtra("auto")) {
+                ResultReturner.returnData(receiver, intent, out -> {
+                        int brightness = Settings.System.getInt(
+                                contentResolver,
+                                Settings.System.SCREEN_BRIGHTNESS,
+                                0
+                        );
+                        out.println("{\"brightness\":" + brightness + "}");
+                });
+                return;
+        }
         if (intent.hasExtra("auto")) {
             boolean auto = intent.getBooleanExtra("auto", false);
             Settings.System.putInt(contentResolver, Settings.System.SCREEN_BRIGHTNESS_MODE, auto?Settings.System.SCREEN_BRIGHTNESS_MODE_AUTOMATIC:Settings.System.SCREEN_BRIGHTNESS_MODE_MANUAL);


### PR DESCRIPTION
Return the current screen brightness when no arguments are provided.

Previously, calling `termux-brightness` without arguments showed a usage
message. This now returns the current brightness value instead:

  {"brightness":149}

Existing behavior for setting brightness is unchanged. No new permissions
are introduced.