### PR TITLE
new Settings API  : read write settings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
     <uses-permission android:name="android.permission.TRANSMIT_IR" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.DUMP" tools:ignore="ProtectedPermissions" />

--- a/app/src/main/java/com/termux/api/TermuxApiReceiver.java
+++ b/app/src/main/java/com/termux/api/TermuxApiReceiver.java
@@ -31,6 +31,7 @@ import com.termux.api.apis.NotificationAPI;
 import com.termux.api.apis.NotificationListAPI;
 import com.termux.api.apis.SAFAPI;
 import com.termux.api.apis.SensorAPI;
+import com.termux.api.apis.SettingsAPI;
 import com.termux.api.apis.ShareAPI;
 import com.termux.api.apis.SmsInboxAPI;
 import com.termux.api.apis.SmsSendAPI;
@@ -195,6 +196,9 @@ public class TermuxApiReceiver extends BroadcastReceiver {
                 break;
             case "Sensor":
                 SensorAPI.onReceive(context, intent);
+                break;
+            case "Settings":
+                SettingsAPI.onReceive(this, context, intent);
                 break;
             case "Share":
                 ShareAPI.onReceive(this, context, intent);

--- a/app/src/main/java/com/termux/api/apis/SettingsAPI.java
+++ b/app/src/main/java/com/termux/api/apis/SettingsAPI.java
@@ -1,0 +1,197 @@
+package com.termux.api.apis;
+
+import android.app.ActivityManager;
+import android.app.ActivityManager.MemoryInfo;
+import android.app.ApplicationExitInfo;
+import android.content.Context;
+import android.os.Build;
+import android.os.Bundle;
+import android.content.Context;
+import android.content.Intent;
+import android.util.JsonWriter;
+
+import androidx.annotation.RequiresPermission;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.termux.api.TermuxApiReceiver;
+import com.termux.api.util.ResultReturner;
+import com.termux.shared.logger.Logger;
+
+import java.util.List;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import android.content.ContentResolver;
+import android.provider.Settings;
+
+// INDENTATION NOTICE this file indentation is configured for mobile screens . small tall screen  . DON'T CHANGE  it if you edit from desktop computer with large screen and you think it looks wrong to you . it's intentional not a mistake . to reduce unnecessary nesting horizontally and allow set ts=2  in vim tab width 2  spaces only 
+
+// after I wrote JSON I realized all output was only one line . so this will convert to simpler output without json
+// class JsonWriter {
+class myWriter {
+
+StringWriter sw;
+public myWriter(StringWriter s) {
+	sw = s;
+}
+void setIndent(String s){}
+void beginArray(){}
+void endArray(){}
+void value(String s) {
+	if (s == null) {
+		s = "null";
+	// if (s.trim().isEmpty()
+	}	else if (s.isEmpty())
+		s = "nmempty";
+	s += "\n";
+	sw.append(s);
+}
+
+}
+
+public class SettingsAPI {
+
+private static final String LOG_TAG = "SettingsAPI";
+static Context context;
+static TermuxApiReceiver receiver;
+static Intent intent;
+static StringWriter sw;
+// static JsonWriter out;
+static myWriter out;
+
+static ContentResolver cr;
+static String setting;
+static String type;
+
+public static void onReceive(TermuxApiReceiver _receiver, final Context _context, Intent _intent) {
+	Logger.logDebug(LOG_TAG, "onReceive");
+	context = _context;
+	receiver = _receiver;
+	intent = _intent;
+	sw = new StringWriter();
+	// out = new JsonWriter(sw);
+	out = new myWriter(sw);
+	
+	// out.setIndent("  ");
+	out.setIndent("	");
+
+	cr = context.getContentResolver();
+	setting = intent.getStringExtra("setting");
+	type = intent.getStringExtra("type");
+
+	Logger.logInfo(LOG_TAG, "==*==*==*==");
+	Logger.logInfo(LOG_TAG, "received " + intent.toString());
+
+	try {
+		try {
+			// jsonTest();
+			settings();
+		} catch (Exception e) {
+			Logger.logError(LOG_TAG, e.toString());
+			out.value(e.toString());
+		}
+		write();
+	} catch (Exception e) {
+		Logger.logError(LOG_TAG, e.toString());
+	}
+}
+
+static void write() {
+	ResultReturner.returnData(context.getApplicationContext(), intent, new ResultReturner.WithInput() {
+		@Override public void writeResult(PrintWriter _out) throws Exception {
+		try {
+			// Logger.logInfo(LOG_TAG, "printing \n\""+sw+"\"");
+			// out.value("\n");
+			_out.print(sw);
+		} catch (Exception e) {
+			Logger.logError(LOG_TAG, e.toString());
+		}
+		}
+	});
+}
+
+// # [ array of values
+// # { object of key value pair
+/*
+static void jsonTest() throws Exception {
+	Logger.logInfo(LOG_TAG, "JSON test");
+	out.beginArray();
+	out.value("123");
+
+	// out.beginObject();
+	// out.name("on").value(0);
+	// out.value(name);
+	// out.endObject();
+	
+	out.endArray();
+}
+*/
+
+static void get() throws Exception {
+	switch(type) {
+		case "string":
+			String get = Settings.Global.getString(cr, setting);
+			out.value(get);
+			Logger.logInfo(LOG_TAG, "received string \"" + get + "\"");
+			break;
+		case "int":
+			int geti = Settings.Global.getInt(cr, setting);
+			// out.name(geti.toString());
+			out.value(geti+"");
+			Logger.logInfo(LOG_TAG, "received int \"" + geti + "\"");
+			break;
+		default:
+			out.value(type +" is invalid type did you mean string/int");
+			break;
+	}
+}
+
+static void set() throws Exception {
+	String value = intent.getStringExtra("value");
+	Logger.logInfo(LOG_TAG, "received value \""+value+"\"");
+	boolean result = false;
+	switch(type) {
+		case "string":
+			// if (value == null || value.trim().isEmpty()) {
+				// out.value("notice setting empty value");
+			if (value == null)
+				value = "";
+			out.value("setting "+setting+"  to \""+value+"\"");
+			result = Settings.Global.putString(cr, setting, value);
+			break;
+		case "int":
+			if (value == null || value.trim().isEmpty()) {
+				out.value("int value cannot be empty");
+				return;
+			}
+			out.value("setting "+setting+"  to \""+value+"\"");
+			result = Settings.Global.putInt(cr, setting, Integer.parseInt(value));
+			break;
+		default:
+			out.value(type +" is invalid type did you mean string/int");
+			// out.value("correct usage termux-api Settings -a get/set --es type string/int --es setting name");
+			break;
+	}
+	out.value("boolean result: "+result);
+}
+
+static void settings() throws Exception {
+	String action = intent.getAction();
+	Logger.logInfo(LOG_TAG, "received action "+action);
+	// out.beginArray();
+	// out.beginObject();
+	switch(action) {
+		case "get":
+			get();
+			break;
+		case "set":
+			set();
+			break;
+		default:
+			out.value(action+" is invalid action. only get/set accepted");
+			break;
+	}
+	// out.endObject();
+	// out.endArray();
+}
+} // class

--- a/app/src/main/java/com/termux/api/apis/SettingsAPI.java
+++ b/app/src/main/java/com/termux/api/apis/SettingsAPI.java
@@ -81,6 +81,9 @@ public static void onReceive(TermuxApiReceiver _receiver, final Context _context
 	type = intent.getStringExtra("type");
 	domain = intent.getStringExtra("domain");
 
+	if (type == null)
+		type = "string";
+
 	Logger.logInfo(LOG_TAG, "==*==*==*==");
 	Logger.logInfo(LOG_TAG, "received " + intent.toString());
 
@@ -185,7 +188,7 @@ static void set() throws Exception {
 				// out.value("notice setting empty value");
 			if (value == null)
 				value = "";
-			out.value("setting "+setting+"  to \""+value+"\"");
+			out.value("setting "+setting+" to \""+value+"\"");
 			result = setString(value);
 			break;
 		case "int":

--- a/app/src/main/java/com/termux/api/apis/SettingsAPI.java
+++ b/app/src/main/java/com/termux/api/apis/SettingsAPI.java
@@ -62,6 +62,7 @@ static myWriter out;
 static ContentResolver cr;
 static String setting;
 static String type;
+static String domain;
 
 public static void onReceive(TermuxApiReceiver _receiver, final Context _context, Intent _intent) {
 	Logger.logDebug(LOG_TAG, "onReceive");
@@ -78,6 +79,7 @@ public static void onReceive(TermuxApiReceiver _receiver, final Context _context
 	cr = context.getContentResolver();
 	setting = intent.getStringExtra("setting");
 	type = intent.getStringExtra("type");
+	domain = intent.getStringExtra("domain");
 
 	Logger.logInfo(LOG_TAG, "==*==*==*==");
 	Logger.logInfo(LOG_TAG, "received " + intent.toString());
@@ -127,10 +129,37 @@ static void jsonTest() throws Exception {
 }
 */
 
+static String getString() throws Exception {
+	switch(domain) {
+		case "global":
+			return Settings.Global.getString(cr, setting);
+		case "secure":
+			return Settings.Secure.getString(cr, setting);
+		case "system":
+			return Settings.System.getString(cr, setting);
+		default:
+			return domain +" is invalid. valid global/system";
+	}
+}
+
+static boolean setString(String value) throws Exception {
+	switch(domain) {
+		case "global":
+			return Settings.Global.putString(cr, setting, value);
+		case "secure":
+			return Settings.Secure.putString(cr, setting, value);
+		case "system":
+			return Settings.System.putString(cr, setting, value);
+		default:
+			out.value("invalid domain "+domain +" did you mean global/system");
+			return false;
+	}
+}
+
 static void get() throws Exception {
 	switch(type) {
 		case "string":
-			String get = Settings.Global.getString(cr, setting);
+			String get = getString();
 			out.value(get);
 			Logger.logInfo(LOG_TAG, "received string \"" + get + "\"");
 			break;
@@ -157,7 +186,7 @@ static void set() throws Exception {
 			if (value == null)
 				value = "";
 			out.value("setting "+setting+"  to \""+value+"\"");
-			result = Settings.Global.putString(cr, setting, value);
+			result = setString(value);
 			break;
 		case "int":
 			if (value == null || value.trim().isEmpty()) {


### PR DESCRIPTION

replacement for settings app 

adb only required once 

~~~
p="pm grant com.termux.api android.permission"
$p.WRITE_SECURE_SETTINGS
~~~

then you can finally apply the settings you need with out adb and wifi




# notice about regular settings 

you may already know this

this permission  is set from settings app GUI  and can't be set from command

~~~
$p.WRITE_SETTINGS
~~~

it returned some kind of cryptic  error that I googled and learned it was in the GUI 


# example usage

first create this function in shell

~~~
s(){ test -n "$4" && val="--estermux-api Settings -a $1 --es type $2 --es setting $3 --es value $4; }
~~~

string appears to work for int also

~~~
s get int development_settings_enabled
1
s get string development_settings_enabled
1
~~~

but not the other way around 

~~~
s get int airplane_mode_radios
android.provider.Settings$SettingNotFoundException: airplane_mode_radios

s get string airplane_mode_radios
cell,bluetooth,uwb,wifi,wimax
~~~


this illustrate a deleted or null value with  JSON output . an empty array 

~~~
s get string hdmi_cec_set_menu_language_denylist
[]
~~~

and the new single line non JSON plain text output .that I changed to but can be easily changed back . except the extra messages may look weird in JSON  

~~~
s get string hdmi_cec_set_menu_language_denylist
null
~~~


# set empty string same as delete 

if you want to restore default there is no delete 

~~~
settings delete global battery_saver_constants 
~~~

in the API only blank string  but the effect is the same 

the return value is null from empty string 

but I haven't verified this in adb because I could only use it for a minute to set permission for termux user

~~~
s set string battery_saver_constants ""
s get string battery_saver_constants  
null
~~~


# service settings are impossible from  API 

GUI settings like dark mode and navigation  is not controlled by a setting but a service 

I constantly need to change this from GUI when I put my phone in travel pouch 


~~~
cmd overlay enable com.android.internal.systemui.navbar.threebutton
Can't find service: overlay
~~~

and take it out again

~~~
cmd overlay disable com.android.internal.systemui.navbar.threebuttonadb shell cmd overlay enable com.android.internal.systemui.navbar.gestural
~~~

and it would be faster from command but it's impossible outside adb

this service is visible but the setting seems to be restricted to system apps

~~~
cmd uimode night no
java.lang.SecurityException: getNightModeCustomType requires MODIFY_DAY_NIGHT_MODE permission
~~~

and the equivalent API 

~~~
int mode = UiModeManager.MODE_NIGHT_NO;
mUiModeManager.setNightMode(mode);
~~~

I haven't tried this because I never have wifi to test anything in adb

~~~
p="pm grant com.termux.api android.permission"
$p.MODIFY_DAY_NIGHT_MODE
~~~

it may be restricted to system apps if I try to set it from adb





# more about  battery saver especially day night mode 

now I can finally  change battery saver settings . especially the disaster 

~~~
s set string battery_saver_constants enable_night_mode=false
~~~

and it's constantly deleted on my unisoc phones both of them that otherwise works nearly perfectly  

they are called Hisense in south Africa and umidigi in Canada but they are essentially the same phone usually the top seller on Amazon . at least it was in Canada i was lucky to get it again for only 150 Canadian   . and in stores in south Africa at least where I bought it first for around two hundred Canadian  or 150 euros  

searching this problem others  have also complained that this setting is reverted constantly and you have to set it every time you need it 


I had only one phone on a six months food and tent  expedition in Australia and the sun panel broke and caused a disaster . I had to complete  this app when I returned to a bike food tent expedition  Canada  and had a connection and battery again 

and also my alarm timeout patch for termux to make sure it's not left running in the back ground 


# check battery policy before and after setting 

on my unisoc phones battery saver constants is null by default 

save four different files with battery saver on and off and night mode true or false

do this four times for four different files

~~~
dumpsys power | grep -A 128 "Battery saver policy" > bat
~~~

to verify and compare before and after with diff to make sure you didn't change anything else in the policy except the night mode


# the other battery saver setting 

here is another battery setting I have never used or heard of

~~~
s get string battery_saver_device_specific_constants
null
~~~

maybe this one is not reset all the time except at reboot

~~~
s set string battery_saver_device_specific_constants enable_night_mode=false
~~~

I haven't had time to try it until writing this


# keep battery saver on while charging 

some one claimed this would be permanent even after I unplug charging 

~~~
settings put global low_power 1
~~~

or in this case

~~~
s set int low_power 1
~~~

setting this manually somehow magically keep it on while plugged in


this makes absolutely no sense and I haven't tried it but I am looking for a way to always save battery since I always lack it

I have no idea why that should be the case and don't believe it


I will try to set it and check if battery saver policy is still enable

but some one should explain how could it have any idea what enabled it . or how it was enabled by the system or GUI or API 

what I would expect is that the system always set it to 0 when battery is connected to charging 

to restore the automatic battery saver off when charging I'm supposed to do

~~~
dumpsys battery reset
settings put global low_power 0
~~~

this is only available adb . this error is outside adb

~~~
dumpsys battery -h
Can't find service: battery
~~~

but I'm not worried about losing it completely or always have it on while plugged in even but I doubt it's possible 

they are not listening really to the right people or minorities or important minorities 

just because I have a power source doesn't mean I'm home I could still be on expedition 

after testing this stupid idea I find that

settings app is completely blocking battery saver when. plugged in everything is greyed out

when I plug in i get this message as I suspected this idea makes no sense whatsoever 

~~~
logcat -d|ack -i low_pow
05-12 01:58:42.938   910   910 D PowerHAL: PowerSessionManager::updateHintMode: mode: LOW_POWER, enabled: 0
05-12 01:58:42.938   910   910 D PowerHAL: switch mode: 0x00000002 -> 0x7fff0000
~~~

if I run this 


~~~
s set int low_power 1
setting low_power  to "1"
boolean result: true

s get int low_power 1
1
~~~

while plugged in nothing happens in log from power manager that should report on

~~~
05-12 01:57:36.670   910   910 D PowerHAL: PowerSessionManager::updateHintMode: mode: LOW_POWER, enabled: 1
~~~

unlike wifi the setting is not immediately restored to 0 but it's ignored by power manager as I suspected . another fail for Google AI 

I see nothing in policy that would indicate this is possible 

~~~
dumpsys power | grep -A 128 "Battery saver policy"|ack -i low
  mIsBatteryLevelLow=false
~~~

it only says battery is not low probably because I'm charging 

I don't even know what that value means 



# confused with sticky battery saver restored when unplugged 

I think they are talking about or have confused it with sticky mode that I already have

~~~
dumpsys power | grep -A 128 "Battery saver policy"|ack sticky -i
  mSettingBatterySaverEnabledSticky=true
~~~

it only means battery saver comes back after unplugged 

if you keep it plugged in all night battery will drain like crazy because battery saver is disabled 


# PATCH local adb with out wifi please merge this team mankind 

I have prepared these rough outlines for a patch for local ADB access on all phones

john-peterson/platform_packages_apps_settings@adb
john-peterson/platform_frameworks_base@adb

I don't know if user/project@branch is resolved so here are the whole links for the GUI . cli still has no links only a static page

https://github.com/john-peterson/platform_packages_apps_settings/commits/adb
https://github.com/john-peterson/platform_frameworks_base/commits/adb

I'm struggling against this response 

> ¿ ? ¿ don'T yOu guYs havE wIFi ¿ ? ¿ 

these sayings come to mind . different worlds . different strokes  . a world apart . Romeo and Juliet  

they struggle to understand some people  don't have wifi and almost never any connection at all

I have written a long letter on Gerrit and hopefully this patch will land some day for all phones



I looked for these wifi hooks and tried to remove the call back that disable adb demon when wifi state change to disconnect 

~~~
android.net.conn.CONNECTIVITY_CHANGE
android.net.wifi.STATE_CHANGE
~~~

adb sources that I forked

aosp-mirror/platform_packages_apps_settings:src/com/android/settings/development

aosp-mirror/platform_frameworks_base:services/core/java/com/android/server/adb

and ADB native source that doesn't seem to need any patch 

https://android.googlesource.com/platform/packages/modules/adb



# it's impossible to even connect again with no wifi  

even if you are paired it's impossible to connect again all these fail with out wifi  

~~~
development_settings_enabled
adb_wifi_enabled
adb_allowed_connection_time
~~~

if it's off I'm pretty sure this is not allowed but I haven't tried it 

~~~
s set string development_settings_enabled 1
~~~


they plugged all the holes . there is no way to get ADB back with out wifi

notice it return true despite the error  or rather info message in the log

~~~
s get int  adb_wifi_enabled 
0
s set int  adb_wifi_enabled 1
setting adb_wifi_enabled  to "1"
result true
s get int  adb_wifi_enabled
0

logcat -d|ack adb
05-11 18:34:54.752  1317  1338 I AdbDebuggingManager: Not connected to any wireless network. Not enabling adbwifi.
~~~

even if you got this far if you check the source only  the port is written in log not the pairing code

~~~
logcat -d|ack adb -i
logcat -d|ack WirelessDebuggingFrag
Got pairing code port=12345
~~~

I don't know any other way to get the adb port all  network status access  is blocked 

~~~
netstat -plnv |grep adb
netstat: no support for `AF INET (tcp)' on this system.
dumpsys net*|grep adb
~~~
